### PR TITLE
FIx ASB on non-Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,3 @@ src/scaffolding.config
 # JetBrains Rider
 .idea/
 *.sln.iml
-
-# Visual Studio Code
-.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to find out which attributes exist for C# debugging
+    // Use hover for the description of the existing attributes
+    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "ASB",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Tool/bin/Debug/net6.0/Particular.EndpointThroughputCounter.dll",
+            "args": ["azureservicebus", "--resourceId", "{resourceId}", "--queueNameMasks", "Samples"],
+            "cwd": "${workspaceFolder}",
+            "console":"integratedTerminal",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": "SQS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Tool/bin/Debug/net6.0/Particular.EndpointThroughputCounter.dll",
+            "args": ["sqs", 
+            "--queueNameMasks", "FixedAT"],
+            "cwd": "${workspaceFolder}",
+            "console":"integratedTerminal",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+     ]
+ }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Tool/Particular.EndpointThroughputCounter.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/Tool/Particular.EndpointThroughputCounter.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/src/Tool/Particular.EndpointThroughputCounter.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Tool/Commands/AzureServiceBusCommand.cs
+++ b/src/Tool/Commands/AzureServiceBusCommand.cs
@@ -165,13 +165,24 @@ class AzureServiceBusCommand : BaseCommand
     bool TestExecutable(string exe)
     {
         var p = new Process();
-        p.StartInfo.UseShellExecute = true;
-        p.StartInfo.FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "where.exe" : "where";
-        p.StartInfo.Arguments = exe;
-        p.StartInfo.WorkingDirectory = Environment.GetEnvironmentVariable("USERPROFILE");
+        var start = p.StartInfo;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            start.UseShellExecute = true;
+            start.FileName = "where.exe";
+            start.Arguments = exe;
+            start.WorkingDirectory = Environment.GetEnvironmentVariable("USERPROFILE");
+        }
+        else
+        {
+            start.FileName = "/bin/bash";
+            start.Arguments = $"-c \"which {exe}\"";
+            start.UseShellExecute = false;
+            start.CreateNoWindow = true;
+        }
 
         p.Start();
-
         p.WaitForExit();
 
         return p.ExitCode == 0;


### PR DESCRIPTION
`where` is a built-in shell command of csh and zsh. Bash is more common, but has `which` instead of `where`, and has to be executed as a direct shell command `bash -c "which pwsh"`.

Also adds tooling support for running in VSCode.