### PR TITLE
Use squash merges

### DIFF
--- a/.github/workflows/approve-dependencies.yml
+++ b/.github/workflows/approve-dependencies.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge
         if: ${{contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SQS') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.CloudWatch') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SecurityToken')}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Based on the [GitHub CLI docs](https://cli.github.com/manual/gh_pr_merge) using `--squash` will give us squash merges and thus a cleaner history for all the AWS dependencies.