### PR TITLE
Various bugfixes, Azure login enhancements

### DIFF
--- a/src/Tool/Commands/AzureServiceBusCommand.cs
+++ b/src/Tool/Commands/AzureServiceBusCommand.cs
@@ -93,6 +93,7 @@ class AzureServiceBusCommand : BaseCommand
         var name = parts[8];
 
         fullyQualifiedNamespace = $"{name}.{serviceBusDomain}";
+        RunInfo.Add("AzureServiceBusNamespace", fullyQualifiedNamespace);
 
         credentials = authType switch
         {

--- a/src/Tool/Commands/AzureServiceBusCommand.cs
+++ b/src/Tool/Commands/AzureServiceBusCommand.cs
@@ -1,17 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Identity;
-using Azure.Messaging.ServiceBus.Administration;
-using Azure.Monitor.Query;
-using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Particular.EndpointThroughputCounter.Data;
 using Particular.EndpointThroughputCounter.Infra;
 
@@ -69,228 +61,60 @@ class AzureServiceBusCommand : BaseCommand
         return command;
     }
 
-    readonly string resourceId;
-    readonly string subscriptionId;
-    readonly string fullyQualifiedNamespace;
-    readonly TokenCredential credentials;
-    readonly MetricsQueryClient metrics;
-    readonly ServiceBusAdministrationClient serviceBusClient;
+    readonly AzureClient azure;
+
 
     public AzureServiceBusCommand(SharedOptions shared, string resourceId, string serviceBusDomain, string authType)
     : base(shared)
     {
-        this.resourceId = resourceId;
-
-        var parts = resourceId.Split('/');
-        if (parts.Length != 9 || parts[0] != string.Empty || parts[1] != "subscriptions" || parts[3] != "resourceGroups" || parts[5] != "providers" || parts[6] != "Microsoft.ServiceBus" || parts[7] != "namespaces")
-        {
-            throw new Exception("The provided --resourceId value does not look like an Azure Service Bus resourceId. A correct value should take the form '/subscriptions/{GUID}/resourceGroups/{NAME}/providers/Microsoft.ServiceBus/namespaces/{NAME}'.");
-        }
-
-        // May be useful in the future
-        // var resourceGroup = parts[4];
-        subscriptionId = parts[2];
-        var name = parts[8];
-
-        fullyQualifiedNamespace = $"{name}.{serviceBusDomain}";
-        RunInfo.Add("AzureServiceBusNamespace", fullyQualifiedNamespace);
-
-        credentials = authType switch
-        {
-            nameof(EnvironmentCredential) => new EnvironmentCredential(),
-            nameof(ManagedIdentityCredential) => new ManagedIdentityCredential(),
-            nameof(SharedTokenCacheCredential) => new SharedTokenCacheCredential(),
-            nameof(VisualStudioCredential) => new VisualStudioCredential(),
-            nameof(VisualStudioCodeCredential) => new VisualStudioCodeCredential(),
-            nameof(AzureCliCredential) => new AzureCliCredential(),
-            nameof(AzurePowerShellCredential) => new AzurePowerShellCredential(),
-            //nameof(InteractiveBrowserCredential) => new InteractiveBrowserCredential(),
-            _ => new AzureCliCredential()
-        };
-        metrics = new MetricsQueryClient(credentials);
-        serviceBusClient = new ServiceBusAdministrationClient(fullyQualifiedNamespace, credentials);
+        azure = new AzureClient(resourceId, serviceBusDomain, authType);
     }
 
     protected override async Task<QueueDetails> GetData(CancellationToken cancellationToken = default)
     {
-        Out.WriteLine($"Getting data from {fullyQualifiedNamespace}...");
+        Out.WriteLine($"Getting data from {azure.FullyQualifiedNamespace}...");
         var endTime = DateTime.UtcNow.Date.AddDays(1);
         var startTime = endTime.AddDays(-30);
 
-        try
+        var queueNames = await azure.GetQueueNames(cancellationToken);
+
+        Out.WriteLine($"Found {queueNames.Length} queues");
+
+        var results = new List<QueueThroughput>();
+
+        for (var i = 0; i < queueNames.Length; i++)
         {
-            var queueNames = await GetQueueNames(cancellationToken);
+            var queueName = queueNames[i];
 
-            Out.WriteLine($"Found {queueNames.Length} queues");
+            Out.WriteLine($"Gathering metrics for queue {i + 1}/{queueNames.Length}: {queueName}");
 
-            var results = new List<QueueThroughput>();
+            var metricValues = await azure.GetMetrics(queueName, startTime, endTime, cancellationToken);
 
-            for (var i = 0; i < queueNames.Length; i++)
+            if (metricValues is not null)
             {
-                var queueName = queueNames[i];
-
-                Out.WriteLine($"Gathering metrics for queue {i + 1}/{queueNames.Length}: {queueName}");
-
-                var response = await metrics.QueryResourceAsync(resourceId,
-                    new[] { "CompleteMessage" },
-                    new MetricsQueryOptions
-                    {
-                        Filter = $"EntityName eq '{queueName}'",
-                        TimeRange = new QueryTimeRange(startTime, endTime),
-                        Granularity = TimeSpan.FromDays(1)
-                    },
-                    cancellationToken);
-
-                // Yeah, it's buried deep
-                var metricValues = response.Value.Metrics.FirstOrDefault()?.TimeSeries.FirstOrDefault()?.Values;
-
-                if (metricValues is not null)
-                {
-                    var maxThroughput = metricValues.Select(timeEntry => timeEntry.Total).Max();
-                    results.Add(new QueueThroughput { QueueName = queueName, Throughput = (int?)maxThroughput });
-                }
+                var maxThroughput = metricValues.Select(timeEntry => timeEntry.Total).Max();
+                results.Add(new QueueThroughput { QueueName = queueName, Throughput = (int?)maxThroughput });
             }
-
-            return new QueueDetails
-            {
-                StartTime = new DateTimeOffset(startTime, TimeSpan.Zero),
-                EndTime = new DateTimeOffset(endTime, TimeSpan.Zero),
-                Queues = results.OrderBy(q => q.QueueName).ToArray(),
-                TimeOfObservation = TimeSpan.FromDays(1)
-            };
         }
-        catch (CredentialUnavailableException x)
+
+        return new QueueDetails
         {
-            // Azure gives a good error message as part of the exception
-            throw new HaltException(HaltReason.InvalidEnvironment, x.Message);
-        }
-    }
-
-    async Task<string[]> GetQueueNames(CancellationToken cancellationToken)
-    {
-        Out.WriteLine($"Authenticating using {credentials.GetType().Name}");
-
-        var queueList = new List<string>();
-
-        try
-        {
-            await foreach (var queue in serviceBusClient.GetQueuesAsync(cancellationToken).WithCancellation(cancellationToken))
-            {
-                queueList.Add(queue.Name);
-            }
-
-            return queueList
-                .OrderBy(name => name)
-                .ToArray();
-        }
-        catch (AuthenticationFailedException afx)
-        {
-            throw new HaltException(HaltReason.Auth, "Unable to get queue information because authentication failed.", afx);
-        }
-        catch (UnauthorizedAccessException uax)
-        {
-            throw new HaltException(HaltReason.Auth, "Unable to get queue information because the authenticated user is not authorized.", uax);
-        }
+            StartTime = new DateTimeOffset(startTime, TimeSpan.Zero),
+            EndTime = new DateTimeOffset(endTime, TimeSpan.Zero),
+            Queues = results.OrderBy(q => q.QueueName).ToArray(),
+            TimeOfObservation = TimeSpan.FromDays(1)
+        };
     }
 
     protected override Task<EnvironmentDetails> GetEnvironment(CancellationToken cancellationToken = default)
     {
-        if (credentials is AzureCliCredential)
-        {
-            OutputCliCredentialsDiagnostics();
-        }
+        azure.OutputCredentialDiagnostics();
 
         return Task.FromResult(new EnvironmentDetails
         {
             MessageTransport = "AzureServiceBus",
-            ReportMethod = $"AzureServiceBus Metrics: {fullyQualifiedNamespace}",
+            ReportMethod = $"AzureServiceBus Metrics: {azure.FullyQualifiedNamespace}",
             SkipEndpointListCheck = true
         });
-    }
-
-    void OutputCliCredentialsDiagnostics()
-    {
-        const string endMsg = " It's possible that authentication will not work. If not, try re-authenticating with the Azure CLI as described in https://docs.particular.net/nservicebus/throughput-tool/azure-service-bus#prerequisites";
-
-        try
-        {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var settingsPath = Path.Combine(home, ".azure");
-
-            if (!Directory.Exists(settingsPath))
-            {
-                Out.WriteWarn("Could not locate $HOME/.azure directory, it's possible that authentication will not work.");
-                return;
-            }
-
-            var configPath = Path.Combine(settingsPath, "config");
-            var cloudConfigPath = Path.Combine(settingsPath, "clouds.config");
-            var profilePath = Path.Combine(settingsPath, "azureProfile.json");
-
-            if (!File.Exists(cloudConfigPath) || !File.Exists(profilePath) || !File.Exists(configPath))
-            {
-                Out.WriteWarn("Could not locate configuration files in $HOME/.azure directory." + endMsg);
-                return;
-            }
-
-            var cloudName = new ConfigurationBuilder()
-                .SetBasePath(settingsPath)
-                .AddIniFile("config")
-                .Build()
-                .GetValue<string>("cloud:name");
-
-            if (string.IsNullOrEmpty(cloudName))
-            {
-                Out.WriteWarn("Could not determine Azure cloud name." + endMsg);
-                return;
-            }
-
-            var currentSubscriptionId = new ConfigurationBuilder()
-                .SetBasePath(settingsPath)
-                .AddIniFile("clouds.config")
-                .Build()
-                .GetValue<string>($"{cloudName}:subscription");
-
-            if (string.IsNullOrEmpty(currentSubscriptionId))
-            {
-                Out.WriteWarn("Could not determine current subscription." + endMsg);
-                return;
-            }
-
-            var profileDoc = JsonConvert.DeserializeObject<JObject>(File.ReadAllText(profilePath));
-            if (profileDoc is null)
-            {
-                Out.WriteWarn("Could not read Azure CLI profile information." + endMsg);
-                return;
-            }
-
-            if (profileDoc.SelectToken($"$.subscriptions[?(@.id == '{currentSubscriptionId}')]") is not JObject currentSubscription)
-            {
-                Out.WriteWarn("Could not find current subscription in Azure CLI profile." + endMsg);
-                return;
-            }
-
-            var subName = currentSubscription.Value<string>("name");
-            var user = currentSubscription["user"].Value<string>("name");
-
-            if (subName is null && user is not null)
-            {
-                Out.WriteLine($"Using Azure CLI credentials to authenticate to {cloudName} subscription '{subName}' as user '{user}'");
-            }
-            else
-            {
-                Out.WriteWarn("Could not determine Azure subscription name or login user." + endMsg);
-                return;
-            }
-
-            if (currentSubscriptionId != subscriptionId)
-            {
-                Out.WriteWarn("The current subscriptionId does not appear to match the subsciptionId in provided Azure Service Bus Resource ID." + endMsg);
-            }
-        }
-        catch (Exception x)
-        {
-            Out.WriteWarn($"An error occurred trying to validate Azure Service Bus login information.{endMsg}{Environment.NewLine}Original exception message: {x.Message}");
-        }
     }
 }

--- a/src/Tool/Commands/BaseCommand.cs
+++ b/src/Tool/Commands/BaseCommand.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Particular.EndpointThroughputCounter.Data;
+using Particular.EndpointThroughputCounter.Infra;
 
 abstract class BaseCommand
 {
@@ -15,6 +16,7 @@ abstract class BaseCommand
 
     public BaseCommand(SharedOptions shared)
     {
+        RunInfo.Add("Command", GetType().Name);
         this.shared = shared;
 #if DEBUG
         PollingRunTime = TimeSpan.FromMinutes(1);

--- a/src/Tool/Commands/RabbitMqCommand.cs
+++ b/src/Tool/Commands/RabbitMqCommand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Particular.EndpointThroughputCounter.Data;
+using Particular.EndpointThroughputCounter.Infra;
 
 class RabbitMqCommand : BaseCommand
 {
@@ -25,6 +26,8 @@ class RabbitMqCommand : BaseCommand
             var url = context.ParseResult.GetValueForOption(urlArg);
             var shared = SharedOptions.Parse(context);
             var cancellationToken = context.GetCancellationToken();
+
+            RunInfo.Add("RabbitUrl", url);
 
             var rabbitManagement = new RabbitManagement(url);
             var runner = new RabbitMqCommand(shared, rabbitManagement);

--- a/src/Tool/Commands/ServiceControlCommand.cs
+++ b/src/Tool/Commands/ServiceControlCommand.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Particular.EndpointThroughputCounter.Data;
+using Particular.EndpointThroughputCounter.Infra;
 
 partial class ServiceControlCommand : BaseCommand
 {
@@ -41,6 +42,9 @@ partial class ServiceControlCommand : BaseCommand
             var scUrl = context.ParseResult.GetValueForOption(scUrlArg);
             var monUrl = context.ParseResult.GetValueForOption(monitoringUrlArg);
             var cancellationToken = context.GetCancellationToken();
+
+            RunInfo.Add("ServiceControlUrl", scUrl);
+            RunInfo.Add("MonitoringUrl", monUrl);
 
             var runner = new ServiceControlCommand(shared, scUrl, monUrl);
             await runner.Run(cancellationToken);

--- a/src/Tool/Infra/AzureClient.cs
+++ b/src/Tool/Infra/AzureClient.cs
@@ -1,0 +1,210 @@
+﻿namespace Particular.EndpointThroughputCounter.Infra
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core;
+    using Azure.Identity;
+    using Azure.Messaging.ServiceBus.Administration;
+    using Azure.Monitor.Query;
+    using Azure.Monitor.Query.Models;
+    using Microsoft.Extensions.Configuration;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    class AzureClient
+    {
+        readonly string resourceId;
+        readonly string subscriptionId;
+
+        TokenCredential credentials;
+        MetricsQueryClient metrics;
+        ServiceBusAdministrationClient serviceBusClient;
+
+        public string FullyQualifiedNamespace { get; }
+
+        public AzureClient(string resourceId, string serviceBusDomain, string authType)
+        {
+            this.resourceId = resourceId;
+
+            var parts = resourceId.Split('/');
+            if (parts.Length != 9 || parts[0] != string.Empty || parts[1] != "subscriptions" || parts[3] != "resourceGroups" || parts[5] != "providers" || parts[6] != "Microsoft.ServiceBus" || parts[7] != "namespaces")
+            {
+                throw new Exception("The provided --resourceId value does not look like an Azure Service Bus resourceId. A correct value should take the form '/subscriptions/{GUID}/resourceGroups/{NAME}/providers/Microsoft.ServiceBus/namespaces/{NAME}'.");
+            }
+
+            // May be useful in the future
+            // var resourceGroup = parts[4];
+            subscriptionId = parts[2];
+            var name = parts[8];
+
+            FullyQualifiedNamespace = $"{name}.{serviceBusDomain}";
+            RunInfo.Add("AzureServiceBusNamespace", FullyQualifiedNamespace);
+
+            credentials = authType switch
+            {
+                nameof(EnvironmentCredential) => new EnvironmentCredential(),
+                nameof(ManagedIdentityCredential) => new ManagedIdentityCredential(),
+                nameof(SharedTokenCacheCredential) => new SharedTokenCacheCredential(),
+                nameof(VisualStudioCredential) => new VisualStudioCredential(),
+                nameof(VisualStudioCodeCredential) => new VisualStudioCodeCredential(),
+                nameof(AzureCliCredential) => new AzureCliCredential(),
+                nameof(AzurePowerShellCredential) => new AzurePowerShellCredential(),
+                //nameof(InteractiveBrowserCredential) => new InteractiveBrowserCredential(),
+                _ => new AzureCliCredential()
+            };
+            metrics = new MetricsQueryClient(credentials);
+            serviceBusClient = new ServiceBusAdministrationClient(FullyQualifiedNamespace, credentials);
+        }
+
+        public async Task<IReadOnlyList<MetricValue>> GetMetrics(string queueName, DateTime startTime, DateTime endTime, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var response = await metrics.QueryResourceAsync(resourceId,
+                    new[] { "CompleteMessage" },
+                    new MetricsQueryOptions
+                    {
+                        Filter = $"EntityName eq '{queueName}'",
+                        TimeRange = new QueryTimeRange(startTime, endTime),
+                        Granularity = TimeSpan.FromDays(1)
+                    },
+                    cancellationToken);
+
+                // Yeah, it's buried deep
+                var metricValues = response.Value.Metrics.FirstOrDefault()?.TimeSeries.FirstOrDefault()?.Values;
+
+                return metricValues;
+            }
+            catch (CredentialUnavailableException x)
+            {
+                // Azure gives a good error message as part of the exception
+                throw new HaltException(HaltReason.InvalidEnvironment, x.Message);
+            }
+        }
+
+        public async Task<string[]> GetQueueNames(CancellationToken cancellationToken = default)
+        {
+            Out.WriteLine($"Authenticating using {credentials.GetType().Name}");
+
+            var queueList = new List<string>();
+
+            try
+            {
+                await foreach (var queue in serviceBusClient.GetQueuesAsync(cancellationToken).WithCancellation(cancellationToken))
+                {
+                    queueList.Add(queue.Name);
+                }
+
+                return queueList
+                    .OrderBy(name => name)
+                    .ToArray();
+            }
+            catch (AuthenticationFailedException afx)
+            {
+                throw new HaltException(HaltReason.Auth, "Unable to get queue information because authentication failed.", afx);
+            }
+            catch (UnauthorizedAccessException uax)
+            {
+                throw new HaltException(HaltReason.Auth, "Unable to get queue information because the authenticated user is not authorized.", uax);
+            }
+        }
+
+        public void OutputCredentialDiagnostics()
+        {
+            if (credentials is AzureCliCredential)
+            {
+                OutputCliCredentialsDiagnostics();
+            }
+        }
+
+        void OutputCliCredentialsDiagnostics()
+        {
+            const string endMsg = " It's possible that authentication will not work. If not, try re-authenticating with the Azure CLI as described in https://docs.particular.net/nservicebus/throughput-tool/azure-service-bus#prerequisites";
+
+            try
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var settingsPath = Path.Combine(home, ".azure");
+
+                if (!Directory.Exists(settingsPath))
+                {
+                    Out.WriteWarn("Could not locate $HOME/.azure directory, it's possible that authentication will not work.");
+                    return;
+                }
+
+                var configPath = Path.Combine(settingsPath, "config");
+                var cloudConfigPath = Path.Combine(settingsPath, "clouds.config");
+                var profilePath = Path.Combine(settingsPath, "azureProfile.json");
+
+                if (!File.Exists(cloudConfigPath) || !File.Exists(profilePath) || !File.Exists(configPath))
+                {
+                    Out.WriteWarn("Could not locate configuration files in $HOME/.azure directory." + endMsg);
+                    return;
+                }
+
+                var cloudName = new ConfigurationBuilder()
+                    .SetBasePath(settingsPath)
+                    .AddIniFile("config")
+                    .Build()
+                    .GetValue<string>("cloud:name");
+
+                if (string.IsNullOrEmpty(cloudName))
+                {
+                    Out.WriteWarn("Could not determine Azure cloud name." + endMsg);
+                    return;
+                }
+
+                var currentSubscriptionId = new ConfigurationBuilder()
+                    .SetBasePath(settingsPath)
+                    .AddIniFile("clouds.config")
+                    .Build()
+                    .GetValue<string>($"{cloudName}:subscription");
+
+                if (string.IsNullOrEmpty(currentSubscriptionId))
+                {
+                    Out.WriteWarn("Could not determine current subscription." + endMsg);
+                    return;
+                }
+
+                var profileDoc = JsonConvert.DeserializeObject<JObject>(File.ReadAllText(profilePath));
+                if (profileDoc is null)
+                {
+                    Out.WriteWarn("Could not read Azure CLI profile information." + endMsg);
+                    return;
+                }
+
+                if (profileDoc.SelectToken($"$.subscriptions[?(@.id == '{currentSubscriptionId}')]") is not JObject currentSubscription)
+                {
+                    Out.WriteWarn("Could not find current subscription in Azure CLI profile." + endMsg);
+                    return;
+                }
+
+                var subName = currentSubscription.Value<string>("name");
+                var user = currentSubscription["user"].Value<string>("name");
+
+                if (subName is not null && user is not null)
+                {
+                    Out.WriteLine($"Using Azure CLI credentials to authenticate to {cloudName} subscription '{subName}' as user '{user}'");
+                }
+                else
+                {
+                    Out.WriteWarn("Could not determine Azure subscription name or login user." + endMsg);
+                    return;
+                }
+
+                if (currentSubscriptionId != subscriptionId)
+                {
+                    Out.WriteWarn("The current subscriptionId does not appear to match the subsciptionId in provided Azure Service Bus Resource ID." + endMsg);
+                }
+            }
+            catch (Exception x)
+            {
+                Out.WriteWarn($"An error occurred trying to validate Azure Service Bus login information.{endMsg}{Environment.NewLine}Original exception message: {x.Message}");
+            }
+        }
+    }
+}

--- a/src/Tool/Infra/RunInfo.cs
+++ b/src/Tool/Infra/RunInfo.cs
@@ -1,0 +1,29 @@
+﻿namespace Particular.EndpointThroughputCounter.Infra
+{
+    using System;
+    using System.Collections.Generic;
+    using Mindscape.Raygun4Net;
+
+    public static class RunInfo
+    {
+        static readonly Dictionary<string, string> runValues = new();
+
+        public static readonly string TicketId;
+
+        static RunInfo()
+        {
+            TicketId = Guid.NewGuid().ToString()[..8];
+            runValues.Add("TicketId", TicketId);
+        }
+
+        public static void Add(string key, string value)
+        {
+            runValues[key] = value;
+        }
+
+        public static IRaygunMessageBuilder AddCurrentRunInfo(this IRaygunMessageBuilder builder)
+        {
+            return builder.SetUserCustomData(runValues);
+        }
+    }
+}

--- a/src/Tool/Rabbit/RabbitManagement.cs
+++ b/src/Tool/Rabbit/RabbitManagement.cs
@@ -84,7 +84,7 @@ class RabbitManagement
         {
             var obj = serializer.Deserialize<JObject>(jsonReader);
 
-            var statsDisabled = obj["disable_stats"].Value<bool>();
+            var statsDisabled = obj["disable_stats"]?.Value<bool>() ?? false;
 
             if (statsDisabled)
             {


### PR DESCRIPTION
* Fixes a NullReferenceException if Rabbit doesn't report info about the stats plugin
* Catch HTTP exceptions when trying to talk to a RabbitMQ API that doesn't exist
* Change how Raygun custom data is organized so we can see things like the command used in custom data
* Refactors Azure access into a separate class, and then allows rotating through the various login options, making it possible that accessing ServiceBus and Metrics data could be done with different credentials. Also removes the --authType parameter.