### PR TITLE
Support audit counts in ServiceControl 4.29.0

### DIFF
--- a/src/Data/Report.cs
+++ b/src/Data/Report.cs
@@ -34,7 +34,7 @@
 
         public QueueThroughput[] Queues { get; init; }
 
-        public int TotalThroughput { get; init; }
+        public long TotalThroughput { get; init; }
 
         public int TotalQueues { get; init; }
 
@@ -47,7 +47,7 @@
         public string QueueName { get; set; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? Throughput { get; set; }
+        public long? Throughput { get; set; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool NoDataOrSendOnly { get; init; }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace Particular.EndpointThroughputCounter.Data
         public bool NoDataOrSendOnly { get; set; }
         public string QueueName { get; set; }
         [Newtonsoft.Json.JsonProperty(DefaultValueHandling=Newtonsoft.Json.DefaultValueHandling.Include | Newtonsoft.Json.DefaultValueHandling.Ignore)]
-        public int? Throughput { get; set; }
+        public long? Throughput { get; set; }
     }
     public class Report
     {
@@ -25,7 +25,7 @@ namespace Particular.EndpointThroughputCounter.Data
         public System.DateTimeOffset StartTime { get; set; }
         public string ToolVersion { get; set; }
         public int TotalQueues { get; set; }
-        public int TotalThroughput { get; set; }
+        public long TotalThroughput { get; set; }
     }
     public class SignedReport
     {

--- a/src/Tool/Commands/BaseCommand.cs
+++ b/src/Tool/Commands/BaseCommand.cs
@@ -52,6 +52,7 @@ abstract class BaseCommand
             using (new StreamWriter(outputPath, false))
             {
             }
+            File.Delete(outputPath);
         }
         catch (Exception x)
         {

--- a/src/Tool/Commands/ServiceControlCommand.cs
+++ b/src/Tool/Commands/ServiceControlCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -61,11 +60,9 @@ partial class ServiceControlCommand : BaseCommand
     // So that a run can be done in 3 minutes in debug mode
     const int SampleCount = 3;
     const int MinutesPerSample = 1;
-    const int AuditSamplingPageSize = 5;
 #else
     const int SampleCount = 24;
     const int MinutesPerSample = 60;
-    const int AuditSamplingPageSize = 500;
 #endif
 
     public ServiceControlCommand(SharedOptions shared, string primaryUrl, string monitoringUrl)
@@ -145,202 +142,22 @@ partial class ServiceControlCommand : BaseCommand
 
         var monitoredNames = queueResults.Select(ep => ep.QueueName).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var endpoint in knownEndpoints.Where(ep => !monitoredNames.Contains(ep.Name) && ep.AuditedMessages))
+        var endpointsWithoutMonitoring = knownEndpoints.Where(ep => !monitoredNames.Contains(ep.Name) && ep.AuditedMessages).ToArray();
+        if (endpointsWithoutMonitoring.Any())
         {
-            var fromAuditing = await GetThroughputFromAudits(endpoint.Name, cancellationToken);
-            if (fromAuditing is not null)
+            var auditsFromBinarySearch = new ServiceControlAuditsByBinarySearch(primary, MinutesPerSample);
+
+            foreach (var endpoint in endpointsWithoutMonitoring)
             {
-                queueResults.Add(fromAuditing);
+                var fromAuditing = await auditsFromBinarySearch.GetThroughputFromAudits(endpoint.Name, cancellationToken);
+                if (fromAuditing is not null)
+                {
+                    queueResults.Add(fromAuditing);
+                }
             }
         }
 
         return queueResults.ToArray();
-    }
-
-    async Task<QueueThroughput> GetThroughputFromAudits(string endpointName, CancellationToken cancellationToken)
-    {
-        Out.WriteLine($"Getting throughput from {endpointName} using audit data.");
-
-        try
-        {
-            return await GetThroughputFromAuditsInternal(endpointName, cancellationToken);
-        }
-        catch (ServiceControlDataException x)
-        {
-            Out.WriteError($"Warning: Unable to read ServiceControl data from {x.Url} after {x.Attempts} attempts: {x.Message}");
-            return null;
-        }
-    }
-
-    async Task<QueueThroughput> GetThroughputFromAuditsInternal(string endpointName, CancellationToken cancellationToken)
-    {
-        var collectionPeriodStartTime = DateTime.UtcNow.AddMinutes(-MinutesPerSample);
-
-        async Task<AuditBatch> GetPage(int page)
-        {
-            Debug($"  * Getting page {page}");
-            return await GetAuditBatch(endpointName, page, AuditSamplingPageSize, cancellationToken);
-        }
-
-        var firstPage = await GetPage(1);
-
-        if (!firstPage.IsValid)
-        {
-            return null;
-        }
-
-        if (firstPage.ContainsTime(collectionPeriodStartTime))
-        {
-            return new QueueThroughput { QueueName = endpointName, Throughput = firstPage.MessagesProcessedAfter(collectionPeriodStartTime) };
-        }
-
-        // Goal: arrive with a minimum and maximum page where the collectionPeriodStartTime occurs somewhere in the middle,
-        // and at that point we can start a binary search to find the exact page in the middle contianing that timestamp.
-        // Start with minimum page is one (duh) and maximum page is currently unknown, use -1 to represent that.
-        var minPage = 1;
-        var maxPage = -1;
-
-        // First we need to "guess" which page the collectionPeriodStartTime might exist on based on the time it took to
-        // process the messages that exist on page 1.
-        var estimatedMessagesThisSample = TimeSpan.FromMinutes(MinutesPerSample).TotalSeconds / firstPage.AverageSecondsPerMessage;
-        // Make our educated guess 120% of what the math-based extrapolation tells us so that if the real math estimate is almost exactly right,
-        // the page is ensured to be in the first range for the binary search. This also saves us from double-to-int conversion slicing off
-        // the estimate resulting in the true page being just outside the first min-max page range causing us to have to go to the next range.
-        var estimatedPages = 1.2 * estimatedMessagesThisSample / AuditSamplingPageSize;
-        Debug($"  * Estimating {estimatedPages:0.0} pages");
-
-        // This is not a "normal" for loop because we're not using the same variable in each of the 3 segments.
-        // 1. Start with factor = 1, this expresses a hope that our "guess" from above is accurate
-        // 2. We continue as long as maxPage is set to an actual (positive) number, this is not a "factor < N" situation.
-        //    So this loop is more like a while (maxPage == -1) than a for loop but we have our iteration of factor built in.
-        // 3. Each time the loop runs, we increase the factor - we didn't find the range so we need to try the next range
-        for (var factor = 1; maxPage == -1; factor++)
-        {
-            var attemptPageNum = (int)(factor * estimatedPages);
-            var page = await GetPage(attemptPageNum);
-
-            if (page.ContainsTime(collectionPeriodStartTime))
-            {
-                return new QueueThroughput
-                {
-                    QueueName = endpointName,
-                    Throughput = (AuditSamplingPageSize * (attemptPageNum - 1)) + page.MessagesProcessedAfter(collectionPeriodStartTime)
-                };
-            }
-
-            if (page.DataIsBefore(collectionPeriodStartTime))
-            {
-                // Either we got past the retention period of data, or we're past the sample period
-                // Which means it's time to assign the max page and start the binary search
-                maxPage = attemptPageNum;
-            }
-            else
-            {
-                // We already know we haven't gone far enough, no reason to re-examine
-                // pages lower than this when doing the binary search.
-                minPage = attemptPageNum;
-            }
-        }
-
-        Debug($"  * Starting binary search with min {minPage}, max {maxPage}");
-        // Do a binary search to find the page that represents where 1 hour ago was
-        while (minPage != maxPage)
-        {
-            var middlePageNum = (minPage + maxPage) / 2;
-            var pageData = await GetPage(middlePageNum);
-
-            // If we've backtracked to a page we've hit before, or the page actually contains the time we seek, we're done
-            if (middlePageNum == minPage || middlePageNum == maxPage || pageData.ContainsTime(collectionPeriodStartTime))
-            {
-                Debug($"  * Found => {(AuditSamplingPageSize * (middlePageNum - 1)) + pageData.MessagesProcessedAfter(collectionPeriodStartTime)} messages");
-                return new QueueThroughput
-                {
-                    QueueName = endpointName,
-                    Throughput = (AuditSamplingPageSize * (middlePageNum - 1)) + pageData.MessagesProcessedAfter(collectionPeriodStartTime)
-                };
-            }
-
-            if (pageData.DataIsBefore(collectionPeriodStartTime))
-            {
-                // Went too far, cut out the top half
-                maxPage = middlePageNum;
-            }
-            else if (pageData.DataIsAfter(collectionPeriodStartTime))
-            {
-                // Not far enough, cut out the bottom half
-                minPage = middlePageNum;
-            }
-        }
-
-        // Likely we don't get here, but for completeness
-        var finalPage = await GetPage(minPage);
-        Debug($"  * Catch-All => {(AuditSamplingPageSize * (minPage - 1)) + finalPage.MessagesProcessedAfter(collectionPeriodStartTime)} messages");
-        return new QueueThroughput
-        {
-            QueueName = endpointName,
-            Throughput = (AuditSamplingPageSize * (minPage - 1)) + finalPage.MessagesProcessedAfter(collectionPeriodStartTime)
-        };
-    }
-
-    async Task<AuditBatch> GetAuditBatch(string endpointName, int page, int pageSize, CancellationToken cancellationToken)
-    {
-        var pathAndQuery = $"/endpoints/{endpointName}/messages/?page={page}&per_page={pageSize}&sort=processed_at&direction=desc";
-
-        var arr = await primary.GetData<JArray>(pathAndQuery, cancellationToken);
-
-        var processedAtValues = arr.Select(token => token["processed_at"].Value<DateTime>()).ToArray();
-
-        return new AuditBatch(processedAtValues);
-    }
-
-    record struct AuditBatch
-    {
-        public AuditBatch(DateTime[] timestamps)
-        {
-            this.timestamps = timestamps;
-
-            IsValid = timestamps.Length > 0;
-
-            if (IsValid)
-            {
-                firstMessageProcessedAt = timestamps.Min();
-                lastMessageProcessedAt = timestamps.Max();
-                AverageSecondsPerMessage = (lastMessageProcessedAt - firstMessageProcessedAt).TotalSeconds / timestamps.Length;
-            }
-            else
-            {
-                firstMessageProcessedAt = default;
-                lastMessageProcessedAt = default;
-                AverageSecondsPerMessage = 0;
-            }
-        }
-
-        DateTime[] timestamps;
-        DateTime firstMessageProcessedAt;
-        DateTime lastMessageProcessedAt;
-
-        public double AverageSecondsPerMessage { get; }
-        public bool IsValid { get; }
-
-        public bool ContainsTime(DateTime targetTime)
-        {
-            return timestamps.Length > 0 && firstMessageProcessedAt <= targetTime && targetTime <= lastMessageProcessedAt;
-        }
-
-        public bool DataIsBefore(DateTime cutoff)
-        {
-            return timestamps.Length == 0 || lastMessageProcessedAt < cutoff;
-        }
-
-        public bool DataIsAfter(DateTime cutoff)
-        {
-            return timestamps.Length > 0 && firstMessageProcessedAt > cutoff;
-        }
-
-        public int MessagesProcessedAfter(DateTime cutoff)
-        {
-            return timestamps.Count(dt => dt >= cutoff);
-        }
     }
 
     protected override async Task<EnvironmentDetails> GetEnvironment(CancellationToken cancellationToken = default)
@@ -414,12 +231,6 @@ partial class ServiceControlCommand : BaseCommand
         }
 
         return endpoints;
-    }
-
-    [Conditional("DEBUG")]
-    void Debug(string message)
-    {
-        Out.WriteLine(message);
     }
 
     class ServiceControlEndpoint

--- a/src/Tool/Infra/Extensions.cs
+++ b/src/Tool/Infra/Extensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+public static class Extensions
+{
+    public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+    {
+        if (dictionary.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        return default;
+    }
+}

--- a/src/Tool/Infra/SemVerVersion.cs
+++ b/src/Tool/Infra/SemVerVersion.cs
@@ -1,0 +1,53 @@
+﻿namespace Particular.EndpointThroughputCounter.Infra
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    class SemVerVersion
+    {
+        public Version Version { get; }
+        public string PrereleaseLabel { get; }
+
+        SemVerVersion(Version version, string prereleaseLabel)
+        {
+            Version = version;
+            PrereleaseLabel = prereleaseLabel;
+        }
+
+        public static bool TryParse(string value, out SemVerVersion version)
+        {
+            version = null;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var match = SemVerRegex.Match(value);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            if (!Version.TryParse(match.Groups["MainVersion"].Value, out var stdVersion))
+            {
+                return false;
+            }
+
+            version = new SemVerVersion(stdVersion, match.Groups["PrereleaseLabel"]?.Value);
+            return true;
+        }
+
+        public override string ToString()
+        {
+            if (PrereleaseLabel is null)
+            {
+                return Version.ToString();
+            }
+
+            return $"{Version}-{PrereleaseLabel}";
+        }
+
+        static readonly Regex SemVerRegex = new(@"(?<MainVersion>\d+\.\d+\.\d(\.\d+)?)+(-(?<PrereleaseLabel>[\w\-\.]+))?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+}

--- a/src/Tool/Infra/SemVerVersion.cs
+++ b/src/Tool/Infra/SemVerVersion.cs
@@ -38,6 +38,16 @@
             return true;
         }
 
+        public static SemVerVersion ParseOrDefault(string value)
+        {
+            if (TryParse(value, out var version))
+            {
+                return version;
+            }
+
+            return null;
+        }
+
         public override string ToString()
         {
             if (PrereleaseLabel is null)

--- a/src/Tool/ServiceControl/ServiceControlAuditsByBinarySearch.cs
+++ b/src/Tool/ServiceControl/ServiceControlAuditsByBinarySearch.cs
@@ -1,0 +1,220 @@
+﻿namespace Particular.EndpointThroughputCounter.ServiceControl
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json.Linq;
+    using Particular.EndpointThroughputCounter.Data;
+
+    class ServiceControlAuditsByBinarySearch
+    {
+        readonly ServiceControlClient primary;
+        readonly int minutesPerSample;
+
+#if DEBUG
+        // So that a run can be done in 3 minutes in debug mode
+        const int AuditSamplingPageSize = 5;
+#else
+        const int AuditSamplingPageSize = 500;
+#endif
+        public ServiceControlAuditsByBinarySearch(ServiceControlClient primary, int minutesPerSample)
+        {
+            this.primary = primary;
+            this.minutesPerSample = minutesPerSample;
+        }
+
+        public async Task<QueueThroughput> GetThroughputFromAudits(string endpointName, CancellationToken cancellationToken = default)
+        {
+            Out.WriteLine($"Getting throughput from {endpointName} using audit data.");
+
+            try
+            {
+                return await GetThroughputFromAuditsInternal(endpointName, cancellationToken);
+            }
+            catch (ServiceControlDataException x)
+            {
+                Out.WriteError($"Warning: Unable to read ServiceControl data from {x.Url} after {x.Attempts} attempts: {x.Message}");
+                return null;
+            }
+        }
+
+        async Task<QueueThroughput> GetThroughputFromAuditsInternal(string endpointName, CancellationToken cancellationToken)
+        {
+            var collectionPeriodStartTime = DateTime.UtcNow.AddMinutes(-minutesPerSample);
+
+            async Task<AuditBatch> GetPage(int page)
+            {
+                Debug($"  * Getting page {page}");
+                return await GetAuditBatch(endpointName, page, AuditSamplingPageSize, cancellationToken);
+            }
+
+            var firstPage = await GetPage(1);
+
+            if (!firstPage.IsValid)
+            {
+                return null;
+            }
+
+            if (firstPage.ContainsTime(collectionPeriodStartTime))
+            {
+                return new QueueThroughput { QueueName = endpointName, Throughput = firstPage.MessagesProcessedAfter(collectionPeriodStartTime) };
+            }
+
+            // Goal: arrive with a minimum and maximum page where the collectionPeriodStartTime occurs somewhere in the middle,
+            // and at that point we can start a binary search to find the exact page in the middle contianing that timestamp.
+            // Start with minimum page is one (duh) and maximum page is currently unknown, use -1 to represent that.
+            var minPage = 1;
+            var maxPage = -1;
+
+            // First we need to "guess" which page the collectionPeriodStartTime might exist on based on the time it took to
+            // process the messages that exist on page 1.
+            var estimatedMessagesThisSample = TimeSpan.FromMinutes(minutesPerSample).TotalSeconds / firstPage.AverageSecondsPerMessage;
+            // Make our educated guess 120% of what the math-based extrapolation tells us so that if the real math estimate is almost exactly right,
+            // the page is ensured to be in the first range for the binary search. This also saves us from double-to-int conversion slicing off
+            // the estimate resulting in the true page being just outside the first min-max page range causing us to have to go to the next range.
+            var estimatedPages = 1.2 * estimatedMessagesThisSample / AuditSamplingPageSize;
+            Debug($"  * Estimating {estimatedPages:0.0} pages");
+
+            // This is not a "normal" for loop because we're not using the same variable in each of the 3 segments.
+            // 1. Start with factor = 1, this expresses a hope that our "guess" from above is accurate
+            // 2. We continue as long as maxPage is set to an actual (positive) number, this is not a "factor < N" situation.
+            //    So this loop is more like a while (maxPage == -1) than a for loop but we have our iteration of factor built in.
+            // 3. Each time the loop runs, we increase the factor - we didn't find the range so we need to try the next range
+            for (var factor = 1; maxPage == -1; factor++)
+            {
+                var attemptPageNum = (int)(factor * estimatedPages);
+                var page = await GetPage(attemptPageNum);
+
+                if (page.ContainsTime(collectionPeriodStartTime))
+                {
+                    return new QueueThroughput
+                    {
+                        QueueName = endpointName,
+                        Throughput = (AuditSamplingPageSize * (attemptPageNum - 1)) + page.MessagesProcessedAfter(collectionPeriodStartTime)
+                    };
+                }
+
+                if (page.DataIsBefore(collectionPeriodStartTime))
+                {
+                    // Either we got past the retention period of data, or we're past the sample period
+                    // Which means it's time to assign the max page and start the binary search
+                    maxPage = attemptPageNum;
+                }
+                else
+                {
+                    // We already know we haven't gone far enough, no reason to re-examine
+                    // pages lower than this when doing the binary search.
+                    minPage = attemptPageNum;
+                }
+            }
+
+            Debug($"  * Starting binary search with min {minPage}, max {maxPage}");
+            // Do a binary search to find the page that represents where 1 hour ago was
+            while (minPage != maxPage)
+            {
+                var middlePageNum = (minPage + maxPage) / 2;
+                var pageData = await GetPage(middlePageNum);
+
+                // If we've backtracked to a page we've hit before, or the page actually contains the time we seek, we're done
+                if (middlePageNum == minPage || middlePageNum == maxPage || pageData.ContainsTime(collectionPeriodStartTime))
+                {
+                    Debug($"  * Found => {(AuditSamplingPageSize * (middlePageNum - 1)) + pageData.MessagesProcessedAfter(collectionPeriodStartTime)} messages");
+                    return new QueueThroughput
+                    {
+                        QueueName = endpointName,
+                        Throughput = (AuditSamplingPageSize * (middlePageNum - 1)) + pageData.MessagesProcessedAfter(collectionPeriodStartTime)
+                    };
+                }
+
+                if (pageData.DataIsBefore(collectionPeriodStartTime))
+                {
+                    // Went too far, cut out the top half
+                    maxPage = middlePageNum;
+                }
+                else if (pageData.DataIsAfter(collectionPeriodStartTime))
+                {
+                    // Not far enough, cut out the bottom half
+                    minPage = middlePageNum;
+                }
+            }
+
+            // Likely we don't get here, but for completeness
+            var finalPage = await GetPage(minPage);
+            Debug($"  * Catch-All => {(AuditSamplingPageSize * (minPage - 1)) + finalPage.MessagesProcessedAfter(collectionPeriodStartTime)} messages");
+            return new QueueThroughput
+            {
+                QueueName = endpointName,
+                Throughput = (AuditSamplingPageSize * (minPage - 1)) + finalPage.MessagesProcessedAfter(collectionPeriodStartTime)
+            };
+        }
+
+        async Task<AuditBatch> GetAuditBatch(string endpointName, int page, int pageSize, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = $"/endpoints/{endpointName}/messages/?page={page}&per_page={pageSize}&sort=processed_at&direction=desc";
+
+            var arr = await primary.GetData<JArray>(pathAndQuery, cancellationToken);
+
+            var processedAtValues = arr.Select(token => token["processed_at"].Value<DateTime>()).ToArray();
+
+            return new AuditBatch(processedAtValues);
+        }
+
+        [Conditional("DEBUG")]
+        static void Debug(string message)
+        {
+            Out.WriteLine(message);
+        }
+
+        record struct AuditBatch
+        {
+            public AuditBatch(DateTime[] timestamps)
+            {
+                this.timestamps = timestamps;
+
+                IsValid = timestamps.Length > 0;
+
+                if (IsValid)
+                {
+                    firstMessageProcessedAt = timestamps.Min();
+                    lastMessageProcessedAt = timestamps.Max();
+                    AverageSecondsPerMessage = (lastMessageProcessedAt - firstMessageProcessedAt).TotalSeconds / timestamps.Length;
+                }
+                else
+                {
+                    firstMessageProcessedAt = default;
+                    lastMessageProcessedAt = default;
+                    AverageSecondsPerMessage = 0;
+                }
+            }
+
+            DateTime[] timestamps;
+            DateTime firstMessageProcessedAt;
+            DateTime lastMessageProcessedAt;
+
+            public double AverageSecondsPerMessage { get; }
+            public bool IsValid { get; }
+
+            public bool ContainsTime(DateTime targetTime)
+            {
+                return timestamps.Length > 0 && firstMessageProcessedAt <= targetTime && targetTime <= lastMessageProcessedAt;
+            }
+
+            public bool DataIsBefore(DateTime cutoff)
+            {
+                return timestamps.Length == 0 || lastMessageProcessedAt < cutoff;
+            }
+
+            public bool DataIsAfter(DateTime cutoff)
+            {
+                return timestamps.Length > 0 && firstMessageProcessedAt > cutoff;
+            }
+
+            public int MessagesProcessedAfter(DateTime cutoff)
+            {
+                return timestamps.Count(dt => dt >= cutoff);
+            }
+        }
+    }
+}

--- a/src/Tool/ServiceControl/ServiceControlClient.cs
+++ b/src/Tool/ServiceControl/ServiceControlClient.cs
@@ -1,0 +1,137 @@
+﻿namespace Particular.EndpointThroughputCounter.ServiceControl
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    class ServiceControlClient
+    {
+        static readonly Version MinServiceControlVersion = new Version(4, 21, 8);
+        static readonly JsonSerializer serializer = new JsonSerializer();
+        static readonly AuthenticatingHttpClient http = new AuthenticatingHttpClient(client => client.Timeout = TimeSpan.FromSeconds(10));
+
+        readonly string rootUrl;
+        readonly string paramName;
+        readonly string instanceType;
+
+        public ServiceControlClient(string paramName, string instanceType, string rootUrl)
+        {
+            if (string.IsNullOrWhiteSpace(rootUrl))
+            {
+                throw new HaltException(HaltReason.InvalidConfig, $"The {paramName} option specifying the {instanceType} URL was not provided.");
+            }
+
+            this.paramName = paramName;
+            this.instanceType = instanceType;
+            this.rootUrl = rootUrl.TrimEnd('/');
+        }
+
+        public Task<TJsonType> GetData<TJsonType>(string pathAndQuery, CancellationToken cancellationToken = default)
+            where TJsonType : JToken
+        {
+            return GetData<TJsonType>(pathAndQuery, 1, cancellationToken);
+        }
+
+        public async Task<TJsonType> GetData<TJsonType>(string pathAndQuery, int tryCount, CancellationToken cancellationToken = default)
+            where TJsonType : JToken
+        {
+            if (pathAndQuery is null || !pathAndQuery.StartsWith('/'))
+            {
+                throw new ArgumentException("pathAndQuery must start with a forward slash.");
+            }
+
+            var url = rootUrl + pathAndQuery;
+
+            for (int i = 0; i < tryCount; i++)
+            {
+                try
+                {
+                    using (var stream = await http.GetStreamAsync(url, cancellationToken))
+                    using (var reader = new StreamReader(stream))
+                    using (var jsonReader = new JsonTextReader(reader))
+                    {
+                        return serializer.Deserialize<TJsonType>(jsonReader);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception x)
+                {
+                    if (i + 1 >= tryCount)
+                    {
+                        throw new ServiceControlDataException(url, tryCount, x);
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("Retry loop ended without returning or throwing. This should not happen.");
+        }
+
+        public async Task CheckEndpoint(Func<string, bool> contentTest, CancellationToken cancellationToken = default)
+        {
+            HttpResponseMessage res = null;
+            try
+            {
+                res = await http.SendAsync(new HttpRequestMessage(HttpMethod.Get, rootUrl), cancellationToken);
+            }
+            catch (HttpRequestException hx)
+            {
+                throw new HaltException(HaltReason.InvalidEnvironment, $"The server at {rootUrl} did not respond. The exception message was: {hx.Message}");
+            }
+
+            if (!res.IsSuccessStatusCode)
+            {
+                var b = new StringBuilder($"The server at {rootUrl} returned a non-successful status code: {(int)res.StatusCode} {res.StatusCode}")
+                    .AppendLine()
+                    .AppendLine("Response Headers:");
+
+                foreach (var header in res.Headers)
+                {
+                    _ = b.AppendLine($"  {header.Key}: {header.Value}");
+                }
+
+                throw new HaltException(HaltReason.RuntimeError, b.ToString());
+            }
+
+            if (!res.Headers.TryGetValues("X-Particular-Version", out var versionHeaders))
+            {
+                throw new HaltException(HaltReason.InvalidConfig, $"The server at {rootUrl} specified by parameter {paramName} does not appear to be a ServiceControl instance. Are you sure you have the right URL?");
+            }
+
+            var version = versionHeaders.Select(header => TryGetVersion(header, out var v) ? v : null).FirstOrDefault();
+            Out.WriteLine($"{instanceType} instance at {rootUrl} detected running version {version.ToString(3)}");
+            if (version < MinServiceControlVersion)
+            {
+                throw new HaltException(HaltReason.InvalidEnvironment, $"The {instanceType} instance at {rootUrl} is running version {version.ToString(3)}. The minimum supported version is {MinServiceControlVersion.ToString(3)}.");
+            }
+
+            var content = await res.Content.ReadAsStringAsync(cancellationToken);
+            if (!contentTest(content))
+            {
+                throw new HaltException(HaltReason.InvalidConfig, $"The server at {rootUrl} specified by parameter {paramName} does not appear to be a {instanceType} instance. Are you sure you have the right URL?");
+            }
+        }
+
+        bool TryGetVersion(string versionString, out Version version)
+        {
+            if (Version.TryParse(versionString, out version))
+            {
+                return true;
+            }
+
+            var firstDash = versionString.IndexOf('-');
+            var mainPartIfPrerelease = firstDash >= 0 ? versionString[..firstDash] : null;
+
+            return Version.TryParse(mainPartIfPrerelease, out version);
+        }
+
+    }
+}

--- a/src/Tool/ServiceControl/ServiceControlDataException.cs
+++ b/src/Tool/ServiceControl/ServiceControlDataException.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-partial class ServiceControlCommand
+﻿namespace Particular.EndpointThroughputCounter.ServiceControl
 {
+    using System;
+
     class ServiceControlDataException : Exception
     {
         public string Url { get; }


### PR DESCRIPTION
Along with this PR, I raised the following issue so that ServiceControl 4.29.0 can be made the minimum supported version when it is 1 year old, enabling the removal of some fairly tricky code.

* https://github.com/Particular/Particular.EndpointThroughputCounter/issues/262