### PR TITLE
Use same equality on GroupBy and ToDictionary to avoid duplicate key exception

### DIFF
--- a/src/AppCommon/Commands/ServiceControlCommand.cs
+++ b/src/AppCommon/Commands/ServiceControlCommand.cs
@@ -94,7 +94,7 @@ partial class ServiceControlCommand : BaseCommand
         }
         Out.WriteLine("Sampling complete");
 
-        var queues = allData.GroupBy(q => q.QueueName)
+        var queues = allData.GroupBy(q => q.QueueName, StringComparer.OrdinalIgnoreCase)
             .Select(g => new QueueThroughput { QueueName = g.Key, Throughput = g.Sum(q => q.Throughput) })
             .ToList();
 


### PR DESCRIPTION
The ToDictionary is right below this statement. The whole point of the group-by is to avoid duplicate key exceptions without losing data, but after grouping by case sensitive, the case-insensitive ToDictionary() can cause dupes that break ToDictionary().