### PR TITLE
check for transport_type if transport_customization_type is null

### DIFF
--- a/src/AppCommon/Commands/ServiceControlCommand.cs
+++ b/src/AppCommon/Commands/ServiceControlCommand.cs
@@ -189,9 +189,10 @@ partial class ServiceControlCommand : BaseCommand
         var obj = await primary.GetData<JObject>("/configuration", 5, cancellationToken);
 
         var transportTypeToken = obj["transport"]["transport_customization_type"]
-            ?? throw new HaltException(HaltReason.InvalidEnvironment, "This version of ServiceControl is not supported. Update to a supported version of ServiceControl. See https://docs.particular.net/servicecontrol/upgrades/supported-versions");
+                                 ?? obj["transport"]["transport_type"]
+                                 ?? throw new HaltException(HaltReason.InvalidEnvironment, "This version of ServiceControl is not supported. Update to a supported version of ServiceControl. See https://docs.particular.net/servicecontrol/upgrades/supported-versions");
 
-        var transportCustomizationTypeStr = obj["transport"]["transport_customization_type"].Value<string>();
+        var transportCustomizationTypeStr = transportTypeToken.Value<string>();
 
         var split = transportCustomizationTypeStr.Split(',');
 


### PR DESCRIPTION
Allowing the tool to look for either transport_customization_type or transport_type when evaluating service control versions