### PR TITLE
Error handling was going in tight loop, should only evaluate every 5m

### DIFF
--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -87,7 +87,6 @@ class RabbitMqCommand : BaseCommand
                     tracker.AddData(q);
                 }
             }
-            nextPollTime = DateTime.UtcNow + pollingInterval;
         }
 
         Out.WriteLine("Waiting until next reading...");
@@ -115,6 +114,8 @@ class RabbitMqCommand : BaseCommand
                     Out.WriteWarn($"Encountered error updating statistics, ignoring for now: {x.Message}");
                     Out.WriteDebugTimestamp();
                 }
+
+                nextPollTime = DateTime.UtcNow + pollingInterval;
             }
         });
 


### PR DESCRIPTION
Moving the update of the nextPollTime outside the try/catch so it gets updated to 5m later even if UpdateTrackers fails.