### PR TITLE
Use HTTP to S3 instead of NuGet protocol to check current version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,8 @@ jobs:
 
           aws s3 cp ./binaries/Particular.EndpointThroughputCounter.zip s3://particular.downloads/EndpointThroughputCounter/Particular.EndpointThroughputCounter.zip --content-type application/zip --acl public-read
 
+          echo "Uploading version.txt file to AWS"
+          echo "${{env.MinVerVersion}}" > version.txt
+          aws s3 cp ./version.txt s3://particular.downloads/EndpointThroughputCounter/version.txt --content-type text/plain --acl public-read
+
           echo "Complete"

--- a/src/AppCommon/AppCommon.csproj
+++ b/src/AppCommon/AppCommon.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 

--- a/src/AppCommon/Versioning.cs
+++ b/src/AppCommon/Versioning.cs
@@ -1,8 +1,5 @@
 ﻿using System.Reflection;
 using System.Text.RegularExpressions;
-using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 static class Versioning
@@ -53,31 +50,35 @@ static class Versioning
             return true;
         }
 
-        var logger = NullLogger.Instance;
-        var cache = new SourceCacheContext();
-        var packageSource = new PackageSource("https://f.feedz.io/particular-software/packages/nuget/index.json");
-        var repository = new SourceRepository(packageSource, Repository.Provider.GetCoreV3());
+        const string checkUrl = "https://s3.amazonaws.com/particular.downloads/EndpointThroughputCounter/version.txt";
 
         try
         {
             Out.WriteLine("Checking for latest version...");
-            NuGetVersion[] versions = null;
+            NuGetVersion latest = null;
 
             using (var tokenSource = new CancellationTokenSource(10_000))
+            using (var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token, cancellationToken))
             {
                 try
                 {
-                    var resource = await repository.GetResourceAsync<FindPackageByIdResource>(tokenSource.Token);
-                    versions = (await resource.GetAllVersionsAsync("Particular.EndpointThroughputCounter", cache, logger, tokenSource.Token)).ToArray();
+                    using var http = new HttpClient();
+                    var versionString = await http.GetStringAsync(checkUrl, combinedToken.Token);
+                    latest = new NuGetVersion(versionString.Trim());
                 }
-                catch (OperationCanceledException) when (tokenSource.Token.IsCancellationRequested)
+                catch (OperationCanceledException) when (combinedToken.Token.IsCancellationRequested)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // Shutting down
+                        throw;
+                    }
+                    // 10s timeout
                     Out.WriteWarn("WARNING: Unable to check current version within 10s timeout. The tool will still run, but only the most recent version of the tool should be used.");
                     return true;
                 }
             }
 
-            var latest = versions.OrderByDescending(pkg => pkg.Version).FirstOrDefault();
             var current = new NuGetVersion(NuGetVersion);
 
             if (latest != null && latest > current)
@@ -94,7 +95,7 @@ static class Versioning
                 return false;
             }
         }
-        catch (NuGetProtocolException)
+        catch (HttpRequestException)
         {
             Out.WriteWarn("WARNING: Unable to validate the latest version of the tool. The tool will still run, but only the most recent version of the tool should be used.");
         }

--- a/src/AppCommon/Versioning.cs
+++ b/src/AppCommon/Versioning.cs
@@ -58,15 +58,15 @@ static class Versioning
             NuGetVersion latest = null;
 
             using (var tokenSource = new CancellationTokenSource(10_000))
-            using (var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token, cancellationToken))
+            using (var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token, cancellationToken))
             {
                 try
                 {
                     using var http = new HttpClient();
-                    var versionString = await http.GetStringAsync(checkUrl, combinedToken.Token);
+                    var versionString = await http.GetStringAsync(checkUrl, combinedTokenSource.Token);
                     latest = new NuGetVersion(versionString.Trim());
                 }
-                catch (OperationCanceledException) when (combinedToken.Token.IsCancellationRequested)
+                catch (OperationCanceledException) when (combinedTokenSource.Token.IsCancellationRequested)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.7.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Particular.Approvals" Version="0.5.0" />


### PR DESCRIPTION
Checks https://s3.amazonaws.com/particular.downloads/EndpointThroughputCounter/version.txt for version information instead of a NuGet package source.

File is pre-filled manually but this PR includes the procedure to update the file on every release.