### PR TITLE
Fix vhost-related RabbitMQ issues by requiring a new --vhost param if more than one

### DIFF
--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -19,15 +19,26 @@ class RabbitMqCommand : BaseCommand
 
         command.AddOption(urlArg);
 
+        var vhostArg = new Option<string>(
+            name: "--vhost",
+            description: "The RabbitMQ virtual host to measure")
+        {
+            IsRequired = false
+        };
+
+        command.AddOption(vhostArg);
+
         command.SetHandler(async context =>
         {
             var url = context.ParseResult.GetValueForOption(urlArg);
+            var vhost = context.ParseResult.GetValueForOption(vhostArg);
             var shared = SharedOptions.Parse(context);
             var cancellationToken = context.GetCancellationToken();
 
             RunInfo.Add("RabbitMQUrl", url);
+            RunInfo.Add("VHost", vhost);
 
-            var runner = new RabbitMqCommand(shared, url);
+            var runner = new RabbitMqCommand(shared, url, vhost);
 
             await runner.Run(cancellationToken);
         });
@@ -36,14 +47,16 @@ class RabbitMqCommand : BaseCommand
     }
 
     readonly string managementUrl;
+    readonly string vhost;
     readonly TimeSpan pollingInterval;
     RabbitMQManagementClient _rabbitMQ;
     RabbitMQDetails _rabbitMQDetails;
 
-    public RabbitMqCommand(SharedOptions shared, string managementUrl)
+    public RabbitMqCommand(SharedOptions shared, string managementUrl, string vhost)
         : base(shared)
     {
         this.managementUrl = managementUrl;
+        this.vhost = vhost;
 #if DEBUG
         pollingInterval = TimeSpan.FromSeconds(10);
 #else
@@ -55,7 +68,7 @@ class RabbitMqCommand : BaseCommand
     {
         var httpFactory = await InteractiveHttpAuth.CreateHttpClientFactory(managementUrl.TrimEnd('/') + "/api/overview", cancellationToken: cancellationToken);
 
-        _rabbitMQ = new RabbitMQManagementClient(httpFactory, managementUrl);
+        _rabbitMQ = new RabbitMQManagementClient(httpFactory, managementUrl, vhost);
     }
 
     protected override async Task<QueueDetails> GetData(CancellationToken cancellationToken = default)
@@ -146,11 +159,12 @@ class RabbitMqCommand : BaseCommand
     {
         try
         {
-            _rabbitMQDetails = await _rabbitMQ.GetRabbitDetails(cancellationToken);
+            _rabbitMQDetails = await _rabbitMQ.GetRabbitDetails(vhost, cancellationToken);
 
             Out.WriteLine($"Connected to cluster {_rabbitMQDetails.ClusterName}");
             Out.WriteLine($"  - RabbitMQ Version: {_rabbitMQDetails.RabbitMQVersion}");
             Out.WriteLine($"  - Management Plugin Version: {_rabbitMQDetails.ManagementVersion}");
+            Out.WriteLine($"  - Virtual host: {_rabbitMQDetails.VHost}");
 
             var queueNames = (await _rabbitMQ.GetQueueDetails(cancellationToken))
                 .Where(q => IncludeQueue(q.Name))

--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.Net;
 using Particular.EndpointThroughputCounter.Data;
 using Particular.EndpointThroughputCounter.Infra;
 using Particular.ThroughputQuery;
@@ -66,7 +67,8 @@ class RabbitMqCommand : BaseCommand
 
     protected override async Task Initialize(CancellationToken cancellationToken = default)
     {
-        var httpFactory = await InteractiveHttpAuth.CreateHttpClientFactory(managementUrl.TrimEnd('/') + "/api/overview", cancellationToken: cancellationToken);
+        var defaultCredential = new NetworkCredential("guest", "guest");
+        var httpFactory = await InteractiveHttpAuth.CreateHttpClientFactory(managementUrl.TrimEnd('/') + "/api/overview", defaultCredential: defaultCredential, cancellationToken: cancellationToken);
 
         _rabbitMQ = new RabbitMQManagementClient(httpFactory, managementUrl, vhost);
     }

--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -191,15 +191,6 @@ class RabbitMqCommand : BaseCommand
         {
             return false;
         }
-        if (name is "error" or "audit")
-        {
-            return false;
-        }
-
-        if (name.StartsWith("Particular.", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
 
         return true;
     }

--- a/src/AppCommon/Infra/InteractiveHttpAuth.cs
+++ b/src/AppCommon/Infra/InteractiveHttpAuth.cs
@@ -9,10 +9,10 @@
 
     static class InteractiveHttpAuth
     {
-        public static Task<Func<HttpClient>> CreateHttpClientFactory(string authUrl, int maxTries = 3, Action<HttpClient> configureNewClient = null, CancellationToken cancellationToken = default)
-            => CreateHttpClientFactory(new Uri(authUrl), maxTries, configureNewClient, cancellationToken);
+        public static Task<Func<HttpClient>> CreateHttpClientFactory(string authUrl, int maxTries = 3, Action<HttpClient> configureNewClient = null, NetworkCredential defaultCredential = null, CancellationToken cancellationToken = default)
+            => CreateHttpClientFactory(new Uri(authUrl), maxTries, configureNewClient, defaultCredential, cancellationToken);
 
-        public static async Task<Func<HttpClient>> CreateHttpClientFactory(Uri authUri, int maxTries = 3, Action<HttpClient> configureNewClient = null, CancellationToken cancellationToken = default)
+        public static async Task<Func<HttpClient>> CreateHttpClientFactory(Uri authUri, int maxTries = 3, Action<HttpClient> configureNewClient = null, NetworkCredential defaultCredential = null, CancellationToken cancellationToken = default)
         {
             Uri uriPrefix = null;
 
@@ -27,7 +27,7 @@
 
             var credentials = new CredentialCache();
 
-            NetworkCredential credential = null;
+            NetworkCredential credential = defaultCredential;
             var schemes = Array.Empty<string>();
             string currentUser = null;
 

--- a/src/Query/RabbitMQ/RabbitMQDetails.cs
+++ b/src/Query/RabbitMQ/RabbitMQDetails.cs
@@ -5,10 +5,11 @@
         public string RabbitMQVersion { get; set; }
         public string ManagementVersion { get; set; }
         public string ClusterName { get; set; }
+        public string VHost { get; set; }
 
         public string ToReportMethodString()
         {
-            return $"RabbitMQ v{RabbitMQVersion}, Mgmt v{ManagementVersion}, Cluster {ClusterName}";
+            return $"RabbitMQ v{RabbitMQVersion}, Mgmt v{ManagementVersion}, Cluster {ClusterName}, VHost {VHost}";
         }
     }
 }

--- a/src/Tool/Properties/launchSettings.json
+++ b/src/Tool/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ThroughputTool-RabbitMQ": {
       "commandName": "Project",
-      "commandLineArgs": "rabbitmq --apiUrl http://hostos:15672 --queueNameMasks Samples --customerName \"Particular Software\" --unattended",
+      "commandLineArgs": "rabbitmq --apiUrl http://hostos:15672 --vhost / --queueNameMasks Samples --customerName \"Particular Software\" --unattended",
       "environmentVariables": {
         "IS_DEVELOPMENT": "true"
       }


### PR DESCRIPTION
* Fixes counting issues due to brokers with multiple vhosts
* Reports error/audit and ServiceControl queues so it doesn't look "funny" when a report has maybe some ServiceControl-related queues but not others
* Try the `guest/guest` default login to save some time