### PR TITLE
Remove Rabbit vhost param, report on all queues in all vhosts and (for now) group them

### DIFF
--- a/src/AppCommon/Infra/SharedOptions.cs
+++ b/src/AppCommon/Infra/SharedOptions.cs
@@ -43,9 +43,9 @@ class SharedOptions
         {
             var runtime = result.GetValueForOption(runtimeInHours);
 
-            if (runtime is < 12 or > 24)
+            if (runtime is < 1 or > 24)
             {
-                result.ErrorMessage = "runtime must be between 12 and 24 hours.";
+                result.ErrorMessage = "runtime must be between 1 and 24 hours.";
             }
         });
 

--- a/src/Query/RabbitMQ/RabbitMQDetails.cs
+++ b/src/Query/RabbitMQ/RabbitMQDetails.cs
@@ -5,11 +5,10 @@
         public string RabbitMQVersion { get; set; }
         public string ManagementVersion { get; set; }
         public string ClusterName { get; set; }
-        public string VHost { get; set; }
 
         public string ToReportMethodString()
         {
-            return $"RabbitMQ v{RabbitMQVersion}, Mgmt v{ManagementVersion}, Cluster {ClusterName}, VHost {VHost}";
+            return $"RabbitMQ v{RabbitMQVersion}, Mgmt v{ManagementVersion}, Cluster {ClusterName}";
         }
     }
 }

--- a/src/Query/RabbitMQ/RabbitMQQueueDetails.cs
+++ b/src/Query/RabbitMQ/RabbitMQQueueDetails.cs
@@ -14,6 +14,9 @@
                 AckedMessages = val.Value<long>();
             }
         }
+
+        public string Id => $"{VHost}:{Name}";
+
         public string Name { get; }
         public string VHost { get; }
         public long? AckedMessages { get; }

--- a/src/Tool/Properties/launchSettings.json
+++ b/src/Tool/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ThroughputTool-RabbitMQ": {
       "commandName": "Project",
-      "commandLineArgs": "rabbitmq --apiUrl http://hostos:15672 --vhost / --queueNameMasks Samples --customerName \"Particular Software\" --unattended",
+      "commandLineArgs": "rabbitmq --apiUrl http://hostos:15672 --queueNameMasks Samples --customerName \"Particular Software\" --unattended",
       "environmentVariables": {
         "IS_DEVELOPMENT": "true"
       }


### PR DESCRIPTION
Temporary solution for one customer until I can add the concept of a queue "scope" to be used for vhosts on RabbitMQ and catalog on SqlTransport.