### PR TITLE
RabbitMQQueueDetails parsing doesn't account for duplicated elements

### DIFF
--- a/src/Query/RabbitMQ/RabbitMQQueueDetails.cs
+++ b/src/Query/RabbitMQ/RabbitMQQueueDetails.cs
@@ -1,17 +1,17 @@
 ﻿namespace Particular.ThroughputQuery.RabbitMQ
 {
     using System.Collections.Generic;
-    using System.Text.Json.Nodes;
+    using System.Text.Json;
 
     public class RabbitMQQueueDetails
     {
-        public RabbitMQQueueDetails(JsonNode token)
+        public RabbitMQQueueDetails(JsonElement token)
         {
-            Name = token["name"]!.GetValue<string>();
-            VHost = token["vhost"]!.GetValue<string>();
-            if (token!["message_stats"] is JsonObject stats && stats["ack"] is JsonValue val)
+            Name = token.GetProperty("name").GetString();
+            VHost = token.GetProperty("vhost").GetString();
+            if (token.TryGetProperty("message_stats", out var stats) && stats.TryGetProperty("ack", out var val))
             {
-                AckedMessages = val.GetValue<long>();
+                AckedMessages = val.GetInt64();
             }
         }
 

--- a/src/Tests/.editorconfig
+++ b/src/Tests/.editorconfig
@@ -3,9 +3,15 @@
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = silent
 
+# PS0003: Making the cancellation token optional is not relevant for tests
+dotnet_diagnostic.PS0003.severity = none
+
 # PS0023: DateTime.UtcNow or DateTimeOffset.UtcNow should be used instead of DateTime.Now and DateTimeOffset.Now, unless the value is being used for displaying the current date-time in a user's local time zone
 # This is a client-side tool and we want to know the local time zone in which the tool was run
 dotnet_diagnostic.PS0023.severity = none
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion
 
 # CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = none

--- a/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details.approved.txt
+++ b/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details.approved.txt
@@ -1,0 +1,23 @@
+[
+  {
+    "Id": "vhost1:queue1",
+    "Name": "queue1",
+    "VHost": "vhost1",
+    "AckedMessages": 1,
+    "EndpointIndicators": []
+  },
+  {
+    "Id": "vhost2:queue2",
+    "Name": "queue2",
+    "VHost": "vhost2",
+    "AckedMessages": 2,
+    "EndpointIndicators": []
+  },
+  {
+    "Id": "vhost1:queue3",
+    "Name": "queue3",
+    "VHost": "vhost1",
+    "AckedMessages": null,
+    "EndpointIndicators": []
+  }
+]

--- a/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details_in_old_format.approved.txt
+++ b/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details_in_old_format.approved.txt
@@ -1,0 +1,23 @@
+[
+  {
+    "Id": "vhost1:queue1",
+    "Name": "queue1",
+    "VHost": "vhost1",
+    "AckedMessages": 1,
+    "EndpointIndicators": []
+  },
+  {
+    "Id": "vhost2:queue2",
+    "Name": "queue2",
+    "VHost": "vhost2",
+    "AckedMessages": 2,
+    "EndpointIndicators": []
+  },
+  {
+    "Id": "vhost1:queue3",
+    "Name": "queue3",
+    "VHost": "vhost1",
+    "AckedMessages": null,
+    "EndpointIndicators": []
+  }
+]

--- a/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details_with_paging.approved.txt
+++ b/src/Tests/ApprovalFiles/RabbitMQManagementClientTests.Should_fetch_queue_details_with_paging.approved.txt
@@ -1,0 +1,16 @@
+[
+  {
+    "Id": "vhost1:queue1",
+    "Name": "queue1",
+    "VHost": "vhost1",
+    "AckedMessages": 1,
+    "EndpointIndicators": []
+  },
+  {
+    "Id": "vhost2:queue2",
+    "Name": "queue2",
+    "VHost": "vhost2",
+    "AckedMessages": 2,
+    "EndpointIndicators": []
+  }
+]

--- a/src/Tests/RabbitMQ/RabbitMQManagementClientTests.cs
+++ b/src/Tests/RabbitMQ/RabbitMQManagementClientTests.cs
@@ -4,6 +4,7 @@ namespace Particular.ThroughputQuery.RabbitMQ.Tests
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using Approvals;
     using NUnit.Framework;
     using RabbitMQ;
 
@@ -71,7 +72,152 @@ namespace Particular.ThroughputQuery.RabbitMQ.Tests
             Assert.DoesNotThrowAsync(async () => await client.GetQueueDetails());
         }
 
-        class FakeHttpHandler : HttpClientHandler
+        [Test]
+        public async Task Should_fetch_queue_details()
+        {
+            SendCallback = _ =>
+            {
+                var response = new HttpResponseMessage
+                {
+                    Content = new StringContent("""
+                    {
+                        "items": [
+                            {
+                                "name": "queue1",
+                                "vhost": "vhost1",
+                                "memory": 1024,
+                                "message_stats": {
+                                    "ack": 1
+                                }
+                            },
+                            {
+                                "name": "queue2",
+                                "vhost": "vhost2",
+                                "message_stats": {
+                                    "ack": 2
+                                }
+                            },
+                            {
+                                "name": "queue3",
+                                "vhost": "vhost1"
+                            }
+                        ],
+                        "page": 1,
+                        "page_count": 1,
+                        "page_size": 500,
+                        "total_count": 2
+                    }
+                    """)
+                };
+                return response;
+            };
+
+            Approver.Verify(await client.GetQueueDetails());
+        }
+
+        [Test]
+        public async Task Should_fetch_queue_details_in_old_format()
+        {
+            SendCallback = _ =>
+            {
+                var response = new HttpResponseMessage
+                {
+                    Content = new StringContent("""
+                    [
+                        {
+                            "name": "queue1",
+                            "vhost": "vhost1",
+                            "memory": 1024,
+                            "message_stats": {
+                                "ack": 1
+                            }
+                        },
+                        {
+                            "name": "queue2",
+                            "vhost": "vhost2",
+                            "message_stats": {
+                                "ack": 2
+                            }
+                        },
+                        {
+                            "name": "queue3",
+                            "vhost": "vhost1"
+                        }
+                    ]
+                    """)
+                };
+                return response;
+            };
+
+            Approver.Verify(await client.GetQueueDetails());
+        }
+
+        [Test]
+        public async Task Should_fetch_queue_details_with_paging()
+        {
+            SendCallback = request =>
+            {
+                HttpResponseMessage response = null;
+
+                if (request.RequestUri.ToString().Contains("page=1"))
+                {
+                    response = new HttpResponseMessage
+                    {
+                        Content = new StringContent("""
+                        {
+                            "items": [
+                                {
+                                    "name": "queue1",
+                                    "vhost": "vhost1",
+                                    "memory": 1024,
+                                    "message_stats": {
+                                        "ack": 1
+                                    }
+                                }
+                            ],
+                            "page": 1,
+                            "page_count": 2,
+                            "page_size": 500,
+                            "total_count": 2
+                        }
+                        """)
+                    };
+                }
+                else if (request.RequestUri.ToString().Contains("page=2"))
+                {
+                    response = new HttpResponseMessage
+                    {
+                        Content = new StringContent("""
+                        {
+                            "items": [
+                                {
+                                    "name": "queue2",
+                                    "vhost": "vhost2",
+                                    "message_stats": {
+                                        "ack": 2
+                                    }
+                                }
+                            ],
+                            "page": 2,
+                            "page_count": 2,
+                            "page_size": 500,
+                            "total_count": 2
+                        }
+                        """)
+                    };
+                }
+                else
+                {
+                    throw new Exception();
+                }
+
+                return response;
+            };
+
+            Approver.Verify(await client.GetQueueDetails());
+        }
+
+        sealed class FakeHttpHandler : HttpClientHandler
         {
             public Func<HttpRequestMessage, HttpResponseMessage> SendCallback { get; set; }
 

--- a/src/Tests/RabbitMQ/RabbitMQManagementClientTests.cs
+++ b/src/Tests/RabbitMQ/RabbitMQManagementClientTests.cs
@@ -1,0 +1,83 @@
+namespace Particular.ThroughputQuery.RabbitMQ.Tests
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using RabbitMQ;
+
+    [TestFixture]
+    public class RabbitMQManagementClientTests
+    {
+        FakeHttpHandler httpHandler;
+        RabbitMQManagementClient client;
+
+        [SetUp]
+        public void Setup()
+        {
+            httpHandler = new FakeHttpHandler();
+
+            client = new RabbitMQManagementClient(() => new HttpClient(httpHandler), "http://localhost:15672");
+        }
+
+        [TearDown]
+        public void TearDown() => httpHandler.Dispose();
+        public Func<HttpRequestMessage, HttpResponseMessage> SendCallback
+        {
+            get => httpHandler.SendCallback;
+            set => httpHandler.SendCallback = value;
+        }
+
+
+        [Test]
+        public void Should_handle_duplicated_json_data()
+        {
+            SendCallback = _ =>
+            {
+                var response = new HttpResponseMessage
+                {
+                    Content = new StringContent("""
+                    {
+                        "items": [
+                            {
+                                "name": "queue1",
+                                "vhost": "vhost1",
+                                "memory": 1024,
+                                "memory": 1024,
+                                "message_stats": {
+                                    "ack": 1
+                                }
+                            },
+                            {
+                                "name": "queue2",
+                                "vhost": "vhost2",
+                                "vhost": "vhost2",
+                                "message_stats": {
+                                    "ack": 2
+                                }
+                            }
+                        ],
+                        "page": 1,
+                        "page_count": 1,
+                        "page_size": 500,
+                        "total_count": 2
+                    }
+                    """)
+                };
+                return response;
+            };
+
+            Assert.DoesNotThrowAsync(async () => await client.GetQueueDetails());
+        }
+
+        class FakeHttpHandler : HttpClientHandler
+        {
+            public Func<HttpRequestMessage, HttpResponseMessage> SendCallback { get; set; }
+
+            protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => SendCallback(request);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(SendCallback(request));
+        }
+    }
+}


### PR DESCRIPTION
In some cases, RabbitMQ management API might return json elements with duplicated keys. 

Fixes part of https://github.com/Particular/PlatformBugs/issues/1371

For example, with one of the customers it returned a duplicated `memory` element

```json
{
    "filtered_count": 44,
    "item_count": 44,
    "items": [
        {
            "arguments": {
                "x-queue-type": "quorum"
            },
            "auto_delete": false,
            "consumer_capacity": 1,
            "consumer_utilisation": 1,
            "consumers": 1,
            "durable": true,
            "effective_policy_definition": {},
            "exclusive": false,
            "leader": "rabbit@7509bf5e7b2a",
            "members": [
                "rabbit@7509bf5e7b2a"
            ],
            "memory": 112564,
            "memory": 112564,
```

By accessing the json object dictionary, the dictionary is initialized and cannot contain multiple keys. [JsonElement is more flexible in that regard](https://github.com/dotnet/runtime/issues/71784).

Both this tool and ServiceControl lack proper testing infrastructure in place to reproduce these problems so I ended up manually loading a fake Json payload from a filestream into the parser.