### PR TITLE
Sets the roll forward behavior for the tool to Major

### DIFF
--- a/src/Tool/Particular.EndpointThroughputCounter.csproj
+++ b/src/Tool/Particular.EndpointThroughputCounter.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <ToolCommandName>throughput-counter</ToolCommandName>
     <PackAsTool>True</PackAsTool>
     <Description>A tool to measure per-endpoint throughput of an NServiceBus system.</Description>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tool/Particular.EndpointThroughputCounter.csproj
+++ b/src/Tool/Particular.EndpointThroughputCounter.csproj
@@ -8,6 +8,7 @@
     <PackAsTool>True</PackAsTool>
     <Description>A tool to measure per-endpoint throughput of an NServiceBus system.</Description>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change sets the roll forward behavior to Major, as it is the most appropriate according to https://learn.microsoft.com/en-us/dotnet/core/versions/selection#values.