### PR TITLE
Remove obsoleted credential

### DIFF
--- a/src/Query/AzureServiceBus/AzureClient.cs
+++ b/src/Query/AzureServiceBus/AzureClient.cs
@@ -53,9 +53,6 @@
             yield return new EnvironmentCredential();
             yield return new SharedTokenCacheCredential();
             yield return new VisualStudioCredential();
-#pragma warning disable CS0618 // Type or member is obsolete
-            yield return new VisualStudioCodeCredential();
-#pragma warning restore CS0618 // Type or member is obsolete
 
             // Don't really need this one to take 100s * 4 tries to finally time out
             var opts = new TokenCredentialOptions();


### PR DESCRIPTION
Follow through on #1048 

> This credential is deprecated because the VS Code Azure Account extension on which this credential relies has been deprecated. Consider using other dev-time credentials, such as VisualStudioCredential, AzureCliCredential, AzureDeveloperCliCredential, AzurePowerShellCredential. See the Azure Account extension deprecation notice here: https://github.com/microsoft/vscode-azure-account/issues/964 

We are already using the other credentials, so it is OK to remove this one.