### PR TITLE
Announce when the tool is waiting for interactive input

### DIFF
--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -126,6 +126,7 @@ abstract class BaseCommand
         }
         else
         {
+            Out.WriteAwaitingInput("a customer name is required for the report. Type it and press Enter. To skip this prompt, pass --customerName \"<name>\"; add --unattended for fully non-interactive (CI/automation) runs.");
             while (string.IsNullOrEmpty(shared.CustomerName))
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/AppCommon/Infra/InteractiveHttpAuth.cs
+++ b/src/AppCommon/Infra/InteractiveHttpAuth.cs
@@ -90,6 +90,7 @@
                         }
                         Out.WriteLine();
 
+                        Out.WriteAwaitingInput("credentials are required to continue.");
                         Out.WriteLine($"Enter authentication for {uriPrefix}:");
                         Out.Write("Username: ");
                         currentUser = Out.ReadLine();

--- a/src/AppCommon/Infra/Out.cs
+++ b/src/AppCommon/Infra/Out.cs
@@ -100,6 +100,21 @@ public static class Out
         }
     }
 
+    public static void WriteAwaitingInput(string message)
+    {
+        lock (writePadlock)
+        {
+            var current = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Cyan;
+
+            var line = $"Waiting for input: {message}";
+            Console.WriteLine(line);
+            output.AppendLine(line);
+
+            Console.ForegroundColor = current;
+        }
+    }
+
     public static void WriteDebugTimestamp()
     {
         var message = $" - Debug timestamp: {DateTime.UtcNow:O}";
@@ -147,6 +162,7 @@ public static class Out
     {
         try
         {
+            WriteAwaitingInput("a response is required to continue.");
             Write(prompt);
             Write(" (Y/N): ");
             while (true)


### PR DESCRIPTION
## Problem

The tool blocks on `Console.ReadLine` / `Console.ReadKey` at three interactive points:

- the **customer name** prompt (`BaseCommand`), when `--customerName` isn't supplied;
- the **"Do you wish to proceed?"** confirmation (`Out.Confirm`), when `--unattended` isn't supplied;
- **HTTP/RabbitMQ credentials** (`InteractiveHttpAuth`).

On a seemingly-frozen console this is easily mistaken for a hang. The customer-name prompt is the first interactive point *after* the version check, so a run that's simply waiting for a name looks identical to one that's stuck. This came up in support case 00106424, where the console output ended right at that prompt and the tool was reported as "hanging indefinitely".

## Change

Add `Out.WriteAwaitingInput(string message)` — a highlighted (cyan) notice printed immediately before each blocking prompt — and call it at the three sites above. The customer-name message also points at the flags that avoid the prompt in automated/locked-down environments (`--customerName`, `--unattended`).

No behavior change beyond the extra notice; prompts and reads are unchanged.

## Before / after (customer-name prompt)

Before — silent after the version line, then blocks:

```
Particular.EndpointThroughputCounter 1.34.0 (Sha:...)
Skipping current version check. Please ensure you are not using an outdated version.

Enter customer name:
```

After:

```
Particular.EndpointThroughputCounter 1.34.1-... (Sha:...)
Skipping current version check. Please ensure you are not using an outdated version.

Waiting for input: a customer name is required for the report. Type it and press Enter. To skip this prompt, pass --customerName "<name>"; add --unattended for fully non-interactive (CI/automation) runs.
Enter customer name:
```

With `--customerName "..." --unattended`, no prompt (and no notice) is shown, as before.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors (warnings-as-errors + analyzers).
- Ran the built tool with and without `--customerName`/`--unattended` and confirmed the notice appears only when a prompt will actually block.