### PR TITLE
Newline-terminate interactive prompts so they are actually displayed

### DIFF
--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -129,7 +129,7 @@ abstract class BaseCommand
             while (string.IsNullOrEmpty(shared.CustomerName))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                Out.Write("Enter customer name: ");
+                Out.WriteLine("Enter customer name:");
                 shared.CustomerName = Out.ReadLine();
             }
         }

--- a/src/AppCommon/Infra/InteractiveHttpAuth.cs
+++ b/src/AppCommon/Infra/InteractiveHttpAuth.cs
@@ -91,9 +91,9 @@
                         Out.WriteLine();
 
                         Out.WriteLine($"Enter authentication for {uriPrefix}:");
-                        Out.Write("Username: ");
+                        Out.WriteLine("Username:");
                         currentUser = Out.ReadLine();
-                        Out.Write("Password: ");
+                        Out.WriteLine("Password:");
                         var pass = Out.ReadPassword();
 
                         credential = new NetworkCredential(currentUser, pass);

--- a/src/AppCommon/Infra/Out.cs
+++ b/src/AppCommon/Infra/Out.cs
@@ -147,8 +147,9 @@ public static class Out
     {
         try
         {
-            Write(prompt);
-            Write(" (Y/N): ");
+            // Must end with a newline: a trailing partial line is not rendered by line-oriented
+            // consumers of stdout (PowerShell, CI logs), making the tool look like it has hung.
+            WriteLine($"{prompt} (Y/N): ");
             while (true)
             {
                 var key = Console.ReadKey(true);


### PR DESCRIPTION
Prompts were written with Console.Write, i.e. without a trailing newline. Console.Out auto-flushes, so the bytes do leave the process — but a trailing partial line is not rendered by line-oriented consumers of stdout (PowerShell, CI logs). The prompt is therefore invisible while the tool blocks on the subsequent Console.ReadLine()/ReadKey(), and the tool appears to hang forever with no output and nothing in the event log.

Reported by a customer whose run sat "hung" for three days; it was in fact waiting at an "Enter customer name: " prompt they could never see.

Terminate the prompts with a newline instead. Affects the customer name prompt, the Y/N confirmation, and the HTTP basic-auth username/password prompts.