### PR TITLE
Apply masking to scopes

### DIFF
--- a/src/AppCommon/Commands/AzureServiceBusCommand.cs
+++ b/src/AppCommon/Commands/AzureServiceBusCommand.cs
@@ -171,7 +171,7 @@ class AzureServiceBusCommand : BaseCommand
         {
             MessageTransport = "AzureServiceBus",
             ReportMethod = $"AzureServiceBus Metrics: {azure.FullyQualifiedNamespace}",
-            QueueNames = queueNames,
+            QueueNames = [..queueNames.Select(name => new ScopeAndQueue(null, name))],
             SkipEndpointListCheck = true
         };
     }

--- a/src/AppCommon/Commands/AzureServiceBusCommand.cs
+++ b/src/AppCommon/Commands/AzureServiceBusCommand.cs
@@ -171,7 +171,7 @@ class AzureServiceBusCommand : BaseCommand
         {
             MessageTransport = "AzureServiceBus",
             ReportMethod = $"AzureServiceBus Metrics: {azure.FullyQualifiedNamespace}",
-            QueueNames = [..queueNames.Select(name => new ScopeAndQueue(null, name))],
+            QueueNames = [.. queueNames.Select(name => new ScopeAndQueue(null, name))],
             SkipEndpointListCheck = true
         };
     }

--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -162,35 +162,51 @@ abstract class BaseCommand
                 throw new HaltException(HaltReason.InvalidEnvironment, $"No {queueNoun}s could be discovered. Please check to make sure your configuration is correct.");
             }
 
+            void OutputMaskMapping(string unmaskedLabel, string contentLabel, string[] unmaskedContents)
+            {
+                Out.WriteLine();
+                Out.WriteLine($"Writing {contentLabel} discovered:");
+                Out.WriteLine();
+
+                (string Unmasked, string Masked)[] contents = [.. unmaskedContents.Select(x => (x, shared.Mask(x)))];
+                const string maskedLabel = "Will be reported as";
+                var unmaskedWidth = Math.Max(unmaskedLabel.Length, contents.Max(content => content.Unmasked.Length));
+                var maskedWidth = Math.Max(maskedLabel.Length, contents.Max(content => content.Masked.Length));
+
+                var lineFormat = $" {{0,-{unmaskedWidth}}} | {{1,-{maskedWidth}}}";
+
+                Out.WriteLine(lineFormat, unmaskedLabel, maskedLabel);
+                Out.WriteLine(lineFormat, new string('-', unmaskedWidth), new string('-', maskedWidth));
+                foreach (var (unmasked, masked) in contents)
+                {
+                    Out.WriteLine(lineFormat, unmasked, masked);
+                }
+
+                Out.WriteLine();
+                Out.WriteLine($"The right column shows how {contentLabel} will be reported. If {contentLabel} contain sensitive");
+                Out.WriteLine("or proprietary information, the names can be masked using the --queueNameMasks parameter.");
+            }
+
             var mappedQueueNames = metadata.QueueNames
-                .Select(name => new { Name = name.QueueName, MaskedName = shared.Mask(name.QueueName), name.Scope, MaskedScope = string.IsNullOrEmpty(name.Scope) ? null : shared.Mask(name.Scope) })
+                .Select(queue => new { Name = queue.QueueName, MaskedName = shared.Mask(queue.QueueName) })
                 .ToArray();
 
-            Out.WriteLine();
-            Out.WriteLine($"Writing {queueNoun} names discovered:");
-            Out.WriteLine();
+            OutputMaskMapping($"{queueNounUpper} Name", $"{queueNoun} names", [.. metadata.QueueNames.Select(queue => queue.QueueName)]);
 
-            string leftLabel = $"{queueNounUpper} Name";
-            const string rightLabel = "Will be reported as";
-            var leftWidth = Math.Max(leftLabel.Length, metadata.QueueNames.Select(name => name.QueueName.Length).Max());
-            var rightWidth = Math.Max(rightLabel.Length, mappedQueueNames.Select(set => set.MaskedName.Length).Max());
+            var scopes = metadata.QueueNames
+                .Where(queue => !string.IsNullOrEmpty(queue.Scope))
+                .Select(queue => queue.Scope)
+                .Distinct()
+                .ToArray();
 
-            var lineFormat = $" {{0,-{leftWidth}}} | {{1,-{rightWidth}}}";
-
-            Out.WriteLine(lineFormat, leftLabel, rightLabel);
-            Out.WriteLine(lineFormat, new string('-', leftWidth), new string('-', rightWidth));
-            foreach (var set in mappedQueueNames)
+            if (scopes.Any())
             {
-                Out.WriteLine(lineFormat, set.Name, set.MaskedName);
+                OutputMaskMapping("Scope", "scopes", scopes);
             }
-            Out.WriteLine();
-
-            Out.WriteLine($"The right column shows how {queueNoun} names will be reported. If {queueNoun} names contain sensitive");
-            Out.WriteLine("or proprietary information, the names can be masked using the --queueNameMasks parameter.");
-            Out.WriteLine();
 
             if (!metadata.QueuesAreEndpoints)
             {
+                Out.WriteLine();
                 Out.WriteLine("Not all queues represent logical endpoints. So, although data from all queues will be included");
                 Out.WriteLine("in the report, not all the queues will automatically be included the licensed endpoint count.");
             }

--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -187,10 +187,6 @@ abstract class BaseCommand
                 Out.WriteLine("or proprietary information, the names can be masked using the --queueNameMasks parameter.");
             }
 
-            var mappedQueueNames = metadata.QueueNames
-                .Select(queue => new { Name = queue.QueueName, MaskedName = shared.Mask(queue.QueueName) })
-                .ToArray();
-
             OutputMaskMapping($"{queueNounUpper} Name", $"{queueNoun} names", [.. metadata.QueueNames.Select(queue => queue.QueueName)]);
 
             var scopes = metadata.QueueNames

--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.Amqp.Framing;
 using Particular.EndpointThroughputCounter.Infra;
 using Particular.EndpointThroughputCounter.ServiceControl;
 using Particular.LicensingComponent.Report;
@@ -163,7 +164,7 @@ abstract class BaseCommand
             }
 
             var mappedQueueNames = metadata.QueueNames
-                .Select(name => new { Name = name, Masked = shared.Mask(name) })
+                .Select(name => new { Name = name.QueueName, MaskedName = shared.Mask(name.QueueName), name.Scope, MaskedScope = string.IsNullOrEmpty(name.Scope) ? null : shared.Mask(name.Scope) })
                 .ToArray();
 
             Out.WriteLine();
@@ -172,8 +173,8 @@ abstract class BaseCommand
 
             string leftLabel = $"{queueNounUpper} Name";
             const string rightLabel = "Will be reported as";
-            var leftWidth = Math.Max(leftLabel.Length, metadata.QueueNames.Select(name => name.Length).Max());
-            var rightWidth = Math.Max(rightLabel.Length, mappedQueueNames.Select(set => set.Masked.Length).Max());
+            var leftWidth = Math.Max(leftLabel.Length, metadata.QueueNames.Select(name => name.QueueName.Length).Max());
+            var rightWidth = Math.Max(rightLabel.Length, mappedQueueNames.Select(set => set.MaskedName.Length).Max());
 
             var lineFormat = $" {{0,-{leftWidth}}} | {{1,-{rightWidth}}}";
 
@@ -181,7 +182,7 @@ abstract class BaseCommand
             Out.WriteLine(lineFormat, new string('-', leftWidth), new string('-', rightWidth));
             foreach (var set in mappedQueueNames)
             {
-                Out.WriteLine(lineFormat, set.Name, set.Masked);
+                Out.WriteLine(lineFormat, set.Name, set.MaskedName);
             }
             Out.WriteLine();
 
@@ -238,9 +239,6 @@ abstract class BaseCommand
         }
         else
         {
-            var mappedQueueNames = metadata.QueueNames
-                .Select(name => new { Name = name, Masked = shared.Mask(name) })
-                .ToArray();
             reportData = new Report
             {
                 CustomerName = shared.CustomerName,
@@ -249,12 +247,20 @@ abstract class BaseCommand
                 ToolType = "Throughput Tool",
                 ToolVersion = Versioning.NuGetVersion,
                 Prefix = metadata.Prefix,
+                ScopeType = metadata.ScopeType,
                 StartTime = new DateTimeOffset(DateTime.UtcNow.Date, TimeSpan.Zero),
                 EndTime = new DateTimeOffset(DateTime.UtcNow.Date.AddDays(1), TimeSpan.Zero),
                 ReportDuration = TimeSpan.FromDays(1),
-                Queues = mappedQueueNames.Select(map => new QueueThroughput { QueueName = map.Masked, NameHash = OneWayHasher.CalculateOneWayHash(map.Name), Throughput = 0 }).ToArray(),
+                Queues = [.. metadata.QueueNames.Select(q => new QueueThroughput
+                {
+                    QueueName = shared.Mask(q.QueueName),
+                    NameHash = OneWayHasher.CalculateOneWayHash(q.QueueName),
+                    Scope = string.IsNullOrEmpty(q.Scope) ? q.Scope : shared.Mask(q.Scope),
+                    ScopeHash = string.IsNullOrEmpty(q.Scope) ? "" : OneWayHasher.CalculateOneWayHash(q.Scope),
+                    Throughput = 0
+                })],
                 TotalThroughput = 0,
-                TotalQueues = mappedQueueNames.Length,
+                TotalQueues = metadata.QueueNames.Length,
                 IgnoredQueues = metadata.IgnoredQueues?.Select(q => shared.Mask(q)).ToArray()
             };
         }

--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -211,16 +211,6 @@ abstract class BaseCommand
         {
             var data = await GetData(cancellationToken);
 
-            foreach (var q in data.Queues)
-            {
-                q.NameHash = OneWayHasher.CalculateOneWayHash(q.QueueName);
-                q.QueueName = shared.Mask(q.QueueName);
-                if (q.Throughput.HasValue)
-                {
-                    q.Throughput = Math.Abs(q.Throughput.Value);
-                }
-            }
-
             reportData = new Report
             {
                 CustomerName = shared.CustomerName,
@@ -233,7 +223,14 @@ abstract class BaseCommand
                 StartTime = data.StartTime,
                 EndTime = data.EndTime,
                 ReportDuration = data.TimeOfObservation ?? (data.EndTime - data.StartTime),
-                Queues = data.Queues,
+                Queues = [..data.Queues.Select(q => q with
+                {
+                    NameHash = OneWayHasher.CalculateOneWayHash(q.QueueName),
+                    QueueName = shared.Mask(q.QueueName),
+                    Scope = string.IsNullOrEmpty(q.Scope) ? q.Scope : shared.Mask(q.Scope),
+                    ScopeHash = string.IsNullOrEmpty(q.Scope) ? "" : OneWayHasher.CalculateOneWayHash(q.Scope),
+                    Throughput = q.Throughput.HasValue ? Math.Abs(q.Throughput.Value) : null,
+                })],
                 TotalThroughput = data.Queues.Sum(q => q.Throughput ?? 0),
                 TotalQueues = data.Queues.Length,
                 IgnoredQueues = metadata.IgnoredQueues?.Select(q => shared.Mask(q)).ToArray()

--- a/src/AppCommon/Commands/BaseCommand.cs
+++ b/src/AppCommon/Commands/BaseCommand.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json;
 using System.Text.RegularExpressions;
-using Microsoft.Azure.Amqp.Framing;
 using Particular.EndpointThroughputCounter.Infra;
 using Particular.EndpointThroughputCounter.ServiceControl;
 using Particular.LicensingComponent.Report;

--- a/src/AppCommon/Commands/PostgreSqlCommand.cs
+++ b/src/AppCommon/Commands/PostgreSqlCommand.cs
@@ -119,7 +119,6 @@ class PostgreSqlCommand(SharedOptions shared, string[] connectionStrings) : Base
 
             var databaseCount = tables.Select(t => t.DatabaseName).Distinct().Count();
             var schemaCount = tables.Select(t => $"{t.DatabaseName}/{t.Schema}").Distinct().Count();
-            var queueNames = tables.Select(t => t.DisplayName).OrderBy(x => x).ToArray();
 
             if (databaseCount > 1)
             {
@@ -138,11 +137,13 @@ class PostgreSqlCommand(SharedOptions shared, string[] connectionStrings) : Base
             {
                 getScope = t => null;
             }
+            var queueNames = tables.Select(t => new ScopeAndQueue(getScope(t), t.DisplayName)).OrderBy(x => x.QueueName).ThenBy(x => x.Scope).ToArray();
 
             return new EnvironmentDetails
             {
                 MessageTransport = "PostgreSql",
                 ReportMethod = "PostgreSqlQuery",
+                ScopeType = scopeType,
                 QueueNames = queueNames
             };
         }

--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -1,6 +1,5 @@
 ﻿using System.CommandLine;
 using System.Net;
-using Amazon.Runtime.Telemetry.Tracing;
 using Particular.EndpointThroughputCounter.Infra;
 using Particular.LicensingComponent.Report;
 using Particular.ThroughputQuery;

--- a/src/AppCommon/Commands/RabbitMqCommand.cs
+++ b/src/AppCommon/Commands/RabbitMqCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 using System.Net;
+using Amazon.Runtime.Telemetry.Tracing;
 using Particular.EndpointThroughputCounter.Infra;
 using Particular.LicensingComponent.Report;
 using Particular.ThroughputQuery;
@@ -168,17 +169,22 @@ class RabbitMqCommand : BaseCommand
             Out.WriteLine($"  - RabbitMQ Version: {_rabbitMQDetails.RabbitMQVersion}");
             Out.WriteLine($"  - Management Plugin Version: {_rabbitMQDetails.ManagementVersion}");
 
-            var queueNames = (await _rabbitMQ.GetQueueDetails(cancellationToken))
+            var queues = (await _rabbitMQ.GetQueueDetails(cancellationToken))
                 .Where(q => IncludeQueue(q.Name))
-                .Select(q => q.Name)
+                .ToArray();
+            var useScopes = queues.Select(q => q.VHost).Distinct().Count() > 1;
+            var queueNames = queues
+                .Select(q => new ScopeAndQueue(useScopes ? q.VHost : null, q.Name))
                 .Distinct()
-                .OrderBy(name => name)
+                .OrderBy(x => x.QueueName)
+                .ThenBy(x => x.Scope)
                 .ToArray();
 
             return new EnvironmentDetails
             {
                 MessageTransport = "RabbitMQ",
                 ReportMethod = _rabbitMQDetails.ToReportMethodString(),
+                ScopeType = useScopes ? "VirtualHost" : null,
                 QueueNames = queueNames
             };
         }

--- a/src/AppCommon/Commands/ServiceControlCommand.cs
+++ b/src/AppCommon/Commands/ServiceControlCommand.cs
@@ -233,7 +233,7 @@ partial class ServiceControlCommand : BaseCommand
         {
             MessageTransport = className,
             ReportMethod = "ServiceControl API",
-            QueueNames = knownEndpoints.OrderBy(q => q.Name).Select(q => q.Name).ToArray(),
+            QueueNames = [.. knownEndpoints.OrderBy(q => q.Name).Select(q => new ScopeAndQueue(null, q.Name))],
             QueuesAreEndpoints = true
         };
     }

--- a/src/AppCommon/Commands/SqlServerCommand.cs
+++ b/src/AppCommon/Commands/SqlServerCommand.cs
@@ -181,7 +181,6 @@ class SqlServerCommand : BaseCommand
 
             var catalogCount = tables.Select(t => t.DatabaseName).Distinct().Count();
             var schemaCount = tables.Select(t => $"{t.DatabaseName}/{t.Schema}").Distinct().Count();
-            var queueNames = tables.Select(t => t.DisplayName).OrderBy(x => x).ToArray();
 
             if (catalogCount > 1)
             {
@@ -205,11 +204,13 @@ class SqlServerCommand : BaseCommand
             {
                 getScope = t => null;
             }
+            var queueNames = tables.Select(t => new ScopeAndQueue(getScope(t), t.DisplayName)).OrderBy(x => x.QueueName).ThenBy(x => x.Scope).ToArray();
 
             return new EnvironmentDetails
             {
                 MessageTransport = "SqlTransport",
                 ReportMethod = "SqlServerQuery",
+                ScopeType = scopeType,
                 QueueNames = queueNames
             };
         }

--- a/src/AppCommon/Commands/SqsCommand.cs
+++ b/src/AppCommon/Commands/SqsCommand.cs
@@ -156,7 +156,7 @@ class SqsCommand : BaseCommand
         {
             MessageTransport = "AmazonSQS",
             ReportMethod = "AWS CloudWatch Metrics",
-            QueueNames = queueNames.OrderBy(q => q).ToArray(),
+            QueueNames = [.. queueNames.OrderBy(q => q).Select(q => new ScopeAndQueue(null, q))],
             Prefix = prefix,
             IgnoredQueues = ignoredQueueNames.Any() ? ignoredQueueNames : null,
             SkipEndpointListCheck = true

--- a/src/AppCommon/Data/EnvironmentDetails.cs
+++ b/src/AppCommon/Data/EnvironmentDetails.cs
@@ -2,9 +2,12 @@
 {
     public string MessageTransport { get; init; }
     public string ReportMethod { get; init; }
-    public string[] QueueNames { get; init; }
+    public string ScopeType { get; init; }
+    public ScopeAndQueue[] QueueNames { get; init; }
     public string Prefix { get; init; }
     public string[] IgnoredQueues { get; init; }
     public bool SkipEndpointListCheck { get; init; }
     public bool QueuesAreEndpoints { get; init; }
 }
+
+record ScopeAndQueue(string Scope, string QueueName);

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Particular.Approvals" Version="2.0.1" />
-    <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.1.1" />
+    <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.2.0" />
     <PackageVersion Include="Particular.Packaging" Version="4.5.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
Scopes can potentially contain sensitive information, the same as queue names. This change applies requested masking redaction to scopes.
in addition, if throughput recording was skipped then previously any scope would not be recorded. This has been fixed